### PR TITLE
New kata on the bit-flip code.

### DIFF
--- a/QEC_BitFlipCode/.vscode/extensions.json
+++ b/QEC_BitFlipCode/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+	// See http://go.microsoft.com/fwlink/?LinkId=827846
+	// for the documentation about the extensions.json format
+	"recommendations": [
+		"quantum.quantum-devkit-vscode"
+	]
+}

--- a/QEC_BitFlipCode/.vscode/settings.json
+++ b/QEC_BitFlipCode/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "csharp.suppressDotnetRestoreNotification": true
+}

--- a/QEC_BitFlipCode/.vscode/tasks.json
+++ b/QEC_BitFlipCode/.vscode/tasks.json
@@ -1,0 +1,36 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "command": "dotnet",
+            "args": [
+                "build"
+            ],
+            "type": "process",
+            "group": "build",
+            "presentation": {
+                "reveal": "silent"
+            },
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "test",
+            "command": "dotnet",
+            "args": [
+                "test"
+            ],
+            "type": "process",
+            "group": "test",
+            "presentation": {
+                "echo": true,
+                "reveal": "always",
+                "focus": false,
+                "panel": "shared"
+            },
+            "problemMatcher": "$msCompile"
+        }
+    ]
+}

--- a/QEC_BitFlipCode/QEC_BitFlipCode.csproj
+++ b/QEC_BitFlipCode/QEC_BitFlipCode.csproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <PlatformTarget>x64</PlatformTarget>
+    <IsPackable>false</IsPackable>
+    <RootNamespace>Quantum.Kata.QEC_BitFlipCode</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="README.md" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Quantum.Canon" Version="0.2.1806.3001-preview" />
+    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.2.1806.3001-preview" />
+    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.2.1806.3001-preview" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+  </ItemGroup>
+</Project>

--- a/QEC_BitFlipCode/QEC_BitFlipCode.sln
+++ b/QEC_BitFlipCode/QEC_BitFlipCode.sln
@@ -1,0 +1,36 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26124.0
+MinimumVisualStudioVersion = 15.0.26124.0
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "QEC_BitFlipCode", "QEC_BitFlipCode.csproj", "{74AE1DA0-0B82-46C3-8E5D-2B2FF94DDAB4}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{74AE1DA0-0B82-46C3-8E5D-2B2FF94DDAB4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{74AE1DA0-0B82-46C3-8E5D-2B2FF94DDAB4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{74AE1DA0-0B82-46C3-8E5D-2B2FF94DDAB4}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{74AE1DA0-0B82-46C3-8E5D-2B2FF94DDAB4}.Debug|x64.Build.0 = Debug|Any CPU
+		{74AE1DA0-0B82-46C3-8E5D-2B2FF94DDAB4}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{74AE1DA0-0B82-46C3-8E5D-2B2FF94DDAB4}.Debug|x86.Build.0 = Debug|Any CPU
+		{74AE1DA0-0B82-46C3-8E5D-2B2FF94DDAB4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{74AE1DA0-0B82-46C3-8E5D-2B2FF94DDAB4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{74AE1DA0-0B82-46C3-8E5D-2B2FF94DDAB4}.Release|x64.ActiveCfg = Release|Any CPU
+		{74AE1DA0-0B82-46C3-8E5D-2B2FF94DDAB4}.Release|x64.Build.0 = Release|Any CPU
+		{74AE1DA0-0B82-46C3-8E5D-2B2FF94DDAB4}.Release|x86.ActiveCfg = Release|Any CPU
+		{74AE1DA0-0B82-46C3-8E5D-2B2FF94DDAB4}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {934A6CCD-70C2-4C90-906A-98E22EA575F5}
+	EndGlobalSection
+EndGlobal

--- a/QEC_BitFlipCode/README.md
+++ b/QEC_BitFlipCode/README.md
@@ -1,0 +1,8 @@
+﻿# Welcome!
+
+This kata covers the simplest of the quantum error-correction codes - the three-qubit bit-flip code. This code encodes each logical qubit in three physical qubits and protects against single bit-flip error (equivalent to applying an X gate). In practice quantum systems can have other types of errors, which will be considered in the subsequent katas on quantum error correction.
+
+This code is a quantum equivalent of the classical [repetition code](https://en.wikipedia.org/wiki/Repetition_code), adjusted to take into account the impossibility of simply cloning the quantum state. 
+
+* This code is described in [the error correction article](https://docs.microsoft.com/en-us/quantum/libraries/error-correction) in the Q# documentation.
+* Another description can be found in [the Wikipedia article](https://en.wikipedia.org/wiki/Quantum_error_correction#The_bit_flip_code).

--- a/QEC_BitFlipCode/ReferenceImplementation.qs
+++ b/QEC_BitFlipCode/ReferenceImplementation.qs
@@ -1,0 +1,87 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+//////////////////////////////////////////////////////////////////////
+// This file contains reference solutions to all tasks. 
+// The tasks themselves can be found in Tasks.qs file.
+// We recommend that you try to solve the tasks yourself first,
+// but feel free to look up the solution if you get stuck.
+//////////////////////////////////////////////////////////////////////
+
+namespace Quantum.Kata.QEC_BitFlipCode {
+    open Microsoft.Quantum.Primitive;
+    open Microsoft.Quantum.Canon;
+
+    // Task 1. Parity Measurements
+    operation MeasureParity_Reference (register : Qubit[]) : Result {
+        body {
+            return Measure([PauliZ; PauliZ; PauliZ], register);
+        }
+    }
+
+    // Task 2. Encoding Codewords
+    operation Encode_Reference(register : Qubit[]) : () {
+        body {
+            ApplyToEachA(CNOT(Head(register), _), Rest(register));
+        }
+        adjoint auto;
+    }
+
+    // Task 3. Error Detection I
+    operation DetectErrorOnLeftQubit_Reference (register : Qubit[]) : Result {
+        body {
+            return Measure([PauliZ; PauliZ], register[0..1]);
+        }
+    }
+
+    // Task 4. Error Correction I
+    operation CorrectErrorOnLeftQubit_Reference (register : Qubit[]) : () {
+        body {
+            if (Measure([PauliZ; PauliZ], register[0..1]) == One) {
+                X(register[0]);
+            }
+        }
+    }
+
+    // Task 5. Error Detection II
+    operation DetectErrorOnAnyQubit_Reference (register : Qubit[]) : Int {
+        body {
+            let m1 = Measure([PauliZ; PauliZ], register[0..1]);
+            let m2 = Measure([PauliZ; PauliZ], register[1..2]);
+            if (m1 == One && m2 == Zero) {
+                return 1;
+            }
+            if (m1 == One && m2 == One) {
+                return 2;
+            }
+            if (m1 == Zero && m2 == One) {
+                return 3;
+            }
+            return 0;
+        }
+    }
+
+    // Task 6. Error Correction II
+    operation CorrectErrorOnAnyQubit_Reference (register : Qubit[]) : () {
+        body {
+            let idx = DetectErrorOnAnyQubit_Reference(register);
+            if (idx > 0) {
+                X(register[idx - 1]);
+            }
+        }
+    }
+
+    // Task 7. Logical X Gate
+    operation LogicalX_Reference (register : Qubit[]) : () {
+        body {
+            ApplyToEach(X, register);
+        }
+    }
+
+    // Task 8. Logical Z Gate
+    operation LogicalZ_Reference (register : Qubit[]) : () {
+        body {
+            ApplyToEach(Z, register);
+        }
+    }
+}

--- a/QEC_BitFlipCode/Tasks.qs
+++ b/QEC_BitFlipCode/Tasks.qs
@@ -1,0 +1,159 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+namespace Quantum.Kata.QEC_BitFlipCode {
+    open Microsoft.Quantum.Primitive;
+    open Microsoft.Quantum.Canon;
+
+    //////////////////////////////////////////////////////////////////
+    // Welcome!
+    //////////////////////////////////////////////////////////////////
+
+    // The "Quantum error correction - bit-flip code" quantum kata is 
+    // a series of exercises designed to get you familiar with 
+    // quantum error correction (QEC) and programming in Q#.
+    // It introduces you to the simplest of QEC codes - the three-qubit bit-flip code,
+    // which encodes each logical qubit in three physical qubits 
+    // and protects against single bit-flip error (equivalent to applying an X gate).
+    // In practice quantum systems can have other types of errors, 
+    // which will be considered in the following katas on quantum error correction.
+    //
+    // Each task is wrapped in one operation preceded by the description of the task.
+    // Each task (except tasks in which you have to write a test) has a unit test associated with it,
+    // which initially fails. Your goal is to fill in the blank (marked with // ... comment)
+    // with some Q# code to make the failing test pass.
+    //
+    // The tasks are given in approximate order of increasing difficulty; harder ones are marked with asterisks. 
+
+
+    // Task 1. Parity Measurements
+    //
+    // Input: three qubits (stored as an array of length 3) in an unknown basis state 
+    //        or in a superposition of basis states of the same parity.
+    // Output: the parity of this state using exactly one call to Measure
+    //         encoded as a value of Result type: Zero for parity 0 and One for parity 1.
+    //         The parity of basis state |𝑥₀𝑥₁𝑥₂⟩ is defined as (𝑥₀ ⊕ 𝑥₁ ⊕ 𝑥₂).
+    // After applying the operation the state of the qubits should not change.
+    // Example:
+    // |000⟩, |101⟩ and |011⟩ all have parity 0, while |010⟩ and |111⟩ have parity 1.
+    operation MeasureParity (register : Qubit[]) : Result {
+        body {
+            // Fill in your code here and change the return statement.
+            // ...
+            return Zero;
+        }
+    }
+
+    // Task 2. Encoding Codewords
+    //
+    // Input: three qubits in the state |ψ⟩ ⊗ |00⟩, where |ψ⟩ = α |0⟩ + β |1⟩ is
+    //        the state of the first qubit, i.e., register[0].
+    // Goal: create a state |̅ψ⟩ ≔ α |000⟩ + β |111⟩ on these qubits.
+    operation Encode (register : Qubit[]) : () {
+        body {
+            // ...
+        }
+    }
+
+    // Task 3. Error Detection I
+    //
+    // Input: three qubits that are either in the state  |̅ψ⟩ ≔ α |000⟩ + β |111⟩
+    //        or in the state X𝟙𝟙|̅ψ⟩ = α |100⟩ + β |011⟩.
+    // Note that the second state is the first state with X applied to the first qubit,
+    // which corresponds to an X error happening on the first qubit.
+    // Output: Zero if the input is |̅ψ⟩ (state without the error),
+    //         One if the input is X𝟙𝟙|̅ψ⟩ (state with the error).
+    // After applying the operation the state of the qubits should not change.
+    operation DetectErrorOnLeftQubit (register : Qubit[]) : Result {
+        body {
+            // ...
+            return Zero;
+        }
+    }
+
+    // Task 4. Error Correction I
+    //
+    // Input: three qubits that are either in the state  |̅ψ⟩ ≔ α |000⟩ + β |111⟩
+    //        or in the state X𝟙𝟙|̅ψ⟩ = α |100⟩ + β |011⟩.
+    // Goal: make sure that the qubits are returned to the state |̅ψ⟩
+    //       (i.e., determine whether an X error has occurred, and if so, fix it).
+    operation CorrectErrorOnLeftQubit (register : Qubit[]) : () {
+        body {
+            // Hint: you can use task 3 to figure out which state you are given.
+            // ...
+        }
+    }
+
+    // Task 5. Error Detection II
+    //
+    // Input: three qubits that are either in the state |̅ψ⟩ ≔ α |000⟩ + β |111⟩
+    //        or in one of the states X𝟙𝟙|̅ψ⟩, 𝟙X𝟙|̅ψ⟩ or 𝟙𝟙X|̅ψ⟩
+    //        (i.e., state |̅ψ⟩ with an X error applied to one of the qubits).
+    // Goal: determine whether an X error has occurred, and if so, on which qubit.
+    // Error | Output
+    // ======+=======
+    // None  | 0
+    // X𝟙𝟙   | 1
+    // 𝟙X𝟙   | 2
+    // 𝟙𝟙X   | 3
+    // After applying the operation the state of the qubits should not change.
+    operation DetectErrorOnAnyQubit (register : Qubit[]) : Int {
+        body {
+            // ...
+            return -1;
+        }
+    }
+
+    // Task 6. Error Correction II
+    //
+    // Input: three qubits that are either in the state |̅ψ⟩ ≔ α |000⟩ + β |111⟩
+    //        or in one of the states X𝟙𝟙|̅ψ⟩, 𝟙X𝟙|̅ψ⟩ or 𝟙𝟙X|̅ψ⟩
+    //        (i.e., the qubits start in state |̅ψ⟩ with an X error possibly applied to one of the qubits).
+    // Goal: make sure that the qubits are returned to the state |̅ψ⟩
+    //       (i.e., determine whether an X error has occurred on any qubit, and if so, fix it).
+    operation CorrectErrorOnAnyQubit (register : Qubit[]) : () {
+        body {
+            // ...
+        }
+    }
+
+    //////////////////////////////////////////////////////////////////
+    // All the tasks in this kata have been dealing with X errors on single qubit.
+    // The bit-flip code doesn't allow one to detect or correct a Z error or multiple X errors.
+    // Indeed, a Z error on a logical state |ψ⟩ = α |0⟩ + β |1⟩ encoded using the bit-flip code 
+    // would convert the state |̅ψ⟩ ≔ α |000⟩ + β |111⟩ into α |000⟩ - β |111⟩,
+    // which is a correct code word for logical state α |0⟩ - β |1⟩.
+    // Two X errors (say, on qubits 1 and 2) would convert |̅ψ⟩ to α |110⟩ + β |001⟩,
+    // which is a code word for logical state β |0⟩ + α |1⟩ with one X error on qubit 3.
+    //////////////////////////////////////////////////////////////////
+
+    // Task 7. Logical X Gate
+    //
+    // Input: three qubits that are either in the state |̅ψ⟩ ≔ α |000⟩ + β |111⟩
+    //        or in one of the states X𝟙𝟙|̅ψ⟩, 𝟙X𝟙|̅ψ⟩ or 𝟙𝟙X|̅ψ⟩
+    //        (i.e., state |̅ψ⟩ with an X error applied to one of the qubits).
+    // Goal: apply a logical X operator, i.e., convert the qubits to the state
+    //       ̅X |̅ψ⟩ = β |000⟩ + α |111⟩ or one of the states that can be represented as
+    //       ̅X |̅ψ⟩ with an X error applied to one of the qubits (for example, β |010⟩ + α |101⟩).
+    // If the state has an error, you can fix it, but this is not necessary.
+    operation LogicalX (register : Qubit[]) : () {
+        body {
+            // ...
+        }
+    }
+
+    // Task 8. Logical Z Gate
+    //
+    // Input: three qubits that are either in the state |̅ψ⟩ ≔ α |000⟩ + β |111⟩
+    //        or in one of the states X𝟙𝟙|̅ψ⟩, 𝟙X𝟙|̅ψ⟩ or 𝟙𝟙X|̅ψ⟩
+    //        (i.e., state |̅ψ⟩ with an X error applied to one of the qubits).
+    // Goal: apply a logical Z operator, i.e., convert the qubits to the state
+    //       ̅Z |̅ψ⟩ = α |000⟩ - β |111⟩ or one of the states that can be represented as
+    //       ̅Z |̅ψ⟩ with an X error applied to one of the qubits (for example, α |010⟩ - β |101⟩).
+    // If the state has an error, you can fix it, but this is not necessary.
+    operation LogicalZ (register : Qubit[]) : () {
+        body {
+            // ...
+        }
+    }
+}

--- a/QEC_BitFlipCode/TestSuiteRunner.cs
+++ b/QEC_BitFlipCode/TestSuiteRunner.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+//////////////////////////////////////////////////////////////////////
+// This file contains parts of the testing harness. 
+// You should not modify anything in this file.
+// The tasks themselves can be found in Tasks.qs file.
+//////////////////////////////////////////////////////////////////////
+
+using Microsoft.Quantum.Simulation.XUnit;
+using Microsoft.Quantum.Simulation.Simulators;
+using Xunit.Abstractions;
+using System.Diagnostics;
+
+namespace Quantum.Kata.QEC_BitFlipCode
+{
+    public class TestSuiteRunner
+    {
+        private readonly ITestOutputHelper output;
+
+        public TestSuiteRunner(ITestOutputHelper output)
+        {
+            this.output = output;
+        }
+
+        /// <summary>
+        /// This driver will run all Q# tests (operations named "...Test") 
+        /// that belong to namespace Quantum.Kata.QEC_BitFlipCode.
+        /// </summary>
+        [OperationDriver(TestNamespace = "Quantum.Kata.QEC_BitFlipCode")]
+        public void TestTarget(TestOperation op)
+        {
+            using (var sim = new QuantumSimulator())
+            {
+                // OnLog defines action(s) performed when Q# test calls function Message
+                sim.OnLog += (msg) => { output.WriteLine(msg); };
+                sim.OnLog += (msg) => { Debug.WriteLine(msg); };
+                op.TestOperationRunner(sim);
+            }
+        }
+    }
+}

--- a/QEC_BitFlipCode/Tests.qs
+++ b/QEC_BitFlipCode/Tests.qs
@@ -1,0 +1,355 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+//////////////////////////////////////////////////////////////////////
+// This file contains parts of the testing harness. 
+// You should not modify anything in this file.
+// The tasks themselves can be found in Tasks.qs file.
+//////////////////////////////////////////////////////////////////////
+
+namespace Quantum.Kata.QEC_BitFlipCode {
+    open Microsoft.Quantum.Canon;
+    open Microsoft.Quantum.Primitive;
+    open Microsoft.Quantum.Extensions.Bitwise;
+    open Microsoft.Quantum.Extensions.Convert;
+    open Microsoft.Quantum.Extensions.Math;
+    open Microsoft.Quantum.Extensions.Testing;
+
+    //////////////////////////////////////////////////////////////////////////
+    // Task 01
+    //////////////////////////////////////////////////////////////////////////
+
+    function ToString_Bitmask (bits : Int) : String {
+        let b1 = bits / 4;
+        let b2 = (bits / 2) % 2;
+        let b3 = bits % 2;
+        return $"{b1}{b2}{b3}";
+    }
+
+    operation StatePrep_Bitmask (qs : Qubit[], bits : Int) : () {
+        body {
+            if (bits / 4 == 1) {
+                X(qs[0]);
+            }
+            if ((bits / 2) % 2 == 1) {
+                X(qs[1]);
+            }
+            if (bits % 2 == 1) {
+                X(qs[2]);
+            }
+        }
+        adjoint auto;
+    }
+
+    function FindFirstDiff_Reference (bits1 : Int[], bits2 : Int[]) : Int {
+        mutable firstDiff = -1;
+        for (i in 0 .. Length(bits1)-1) {
+            if (bits1[i] != bits2[i] && firstDiff == -1) {
+                set firstDiff = i;
+            }
+        }
+        return firstDiff;
+    }
+
+    function IntToBoolArray (n : Int) : Int[] {
+        return [(n / 4) % 2; (n / 2) % 2; n % 2];
+    }
+
+    operation StatePrep_TwoBitmasks (qs : Qubit[], bits1 : Int[], bits2 : Int[]) : () {
+        body {
+            let firstDiff = FindFirstDiff_Reference(bits1, bits2);
+
+            H(qs[firstDiff]);
+
+            for (i in 0 .. Length(qs)-1) {
+                if (bits1[i] == bits2[i]) {
+                    if (bits1[i] == 1) {
+                        X(qs[i]);
+                    }
+                } else {
+                    if (i > firstDiff) {
+                        CNOT(qs[firstDiff], qs[i]);
+                        if (bits1[i] != bits1[firstDiff]) {
+                            X(qs[i]);
+                        }
+                    }
+                }
+            }
+        }
+        adjoint auto;
+    }
+
+    operation TestParityOnState (
+        statePrep : (Qubit[] => () : Adjoint),
+        parity : Int,
+        stateStr : String
+        ) : () {
+        body {
+            using (register = Qubit[3]) {
+                // prepare basis state to test on
+                statePrep(register);
+                let res = MeasureParity(register);
+
+                // check that the returned parity is correct
+                AssertBoolEqual(res == Zero, parity == 0, $"Failed on {stateStr}.");
+
+                // check that the state has not been modified
+                (Adjoint statePrep)(register);
+                AssertAllZero(register);
+            }
+        }
+    }
+
+    operation T01_MeasureParity_Test () : () {
+        body {
+            // test on all basis states
+            for (bits in 0..7) {
+                let bitsStr = ToString_Bitmask(bits);
+                TestParityOnState(StatePrep_Bitmask(_, bits), Parity(bits), $"basis state |{bitsStr}⟩");
+            }
+
+            // test on all superpositions of two basis states of the same parity
+            for (b1 in 0..7) {
+                let bits1 = IntToBoolArray(b1);
+                let bitsStr1 = ToString_Bitmask(b1);
+                for (b2 in (b1 + 1)..7) {
+                    if (Parity(b1) == Parity(b2)) {
+                        let bits2 = IntToBoolArray(b2);
+                        let bitsStr2 = ToString_Bitmask(b2);
+                        let p = Parity(b1);
+                        Message($"Testing on |{bitsStr1}⟩ + |{bitsStr2}⟩ with parity {p}");
+                        TestParityOnState(StatePrep_TwoBitmasks(_, bits1, bits2), Parity(b1), 
+                                          $"state |{bitsStr1}⟩ + |{bitsStr2}⟩");
+                    }
+                }
+            }
+        }
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    // Task 02
+    //////////////////////////////////////////////////////////////////////////
+
+    operation AssertEqualOnZeroState (
+        statePrep : (Qubit[] => () : Adjoint),
+        testImpl : (Qubit[] => ()), 
+        refImpl : (Qubit[] => () : Adjoint)
+    ) : () {
+        body {
+            using (qs = Qubit[3]) {
+                // prepare state
+                statePrep(qs);
+
+                // apply operation that needs to be tested
+                testImpl(qs);
+
+                // apply adjoint reference operation and adjoint state prep
+                (Adjoint refImpl)(qs);
+                (Adjoint statePrep)(qs);
+
+                // assert that all qubits end up in |0⟩ state
+                AssertAllZero(qs);
+            }
+        }
+    }
+
+    operation StatePrep_Rotate (qs : Qubit[], alpha : Double) : () {
+        body {
+            Ry(2.0 * alpha, qs[0]);
+        }
+        adjoint auto;
+    }
+
+    operation T02_Encode_Test () : () {
+        body {
+            for (i in 0..36) {
+                let alpha = 2.0 * PI() * ToDouble(i) / 36.0;
+                AssertEqualOnZeroState(StatePrep_Rotate(_, alpha), Encode, Encode_Reference);
+            }
+        }
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    // Task 03
+    //////////////////////////////////////////////////////////////////////////
+
+    operation StatePrep_WithError (qs : Qubit[], alpha : Double, hasError : Bool) : () {
+        body {
+            StatePrep_Rotate(qs, alpha);
+            Encode_Reference(qs);
+            if (hasError) {
+                X(qs[0]);
+            }
+        }
+        adjoint auto;
+    }
+
+    operation T03_DetectErrorOnLeftQubit_Test () : () {
+        body {
+            using (register = Qubit[3]) {
+                for (i in 0..36) {
+                    let alpha = 2.0 * PI() * ToDouble(i) / 36.0;
+                    StatePrep_WithError(register, alpha, false);
+                    AssertResultEqual(DetectErrorOnLeftQubit(register), Zero, "Failed on a state without X error.");
+                    (Adjoint StatePrep_WithError)(register, alpha, false);
+                    AssertAllZero(register);
+
+                    StatePrep_WithError(register, alpha, true);
+                    AssertResultEqual(DetectErrorOnLeftQubit(register), One, "Failed on a state with X error.");
+                    (Adjoint StatePrep_WithError)(register, alpha, true);
+                    AssertAllZero(register);
+                }
+            }
+        }
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    // Task 04
+    //////////////////////////////////////////////////////////////////////////
+
+    operation BindErrorCorrectionRoundImpl (
+        encoder : (Qubit[] => () : Adjoint), 
+        error : Pauli[],
+        logicalOp : (Qubit[] => ()),
+        correction : (Qubit[] => ()),
+
+        dataRegister : Qubit[]
+    ) : () {
+        body {
+            using (auxiliary = Qubit[2]) {
+                let register = dataRegister + auxiliary;
+
+                // encode the logical qubit (dataRegister) into physical representation (register)
+                encoder(register);
+
+                // apply error (or no error)
+                ApplyPauli(error, register);
+
+                // perform logical operation on (possibly erroneous) state
+                logicalOp(register);
+
+                // apply correction to get the state back to correct one
+                correction(register);
+
+                // apply decoding to get back to 1-qubit state
+                (Adjoint encoder)(register);
+
+                AssertAllZero(auxiliary);
+            }
+        }
+    }
+
+    function BindErrorCorrectionRound (
+            encoder : (Qubit[] => () : Adjoint), 
+            error : Pauli[],
+            logicalOp : (Qubit[] => ()),
+            correction : (Qubit[] => ())
+        ) : (Qubit[] => ()) {
+
+        return BindErrorCorrectionRoundImpl(encoder, error, logicalOp, correction, _);
+    }
+
+    // list of errors which can be corrected by the code (the first element corresponds to no error)
+    function PauliErrors() : Pauli[][] {
+        return [
+                [PauliI; PauliI; PauliI];
+                [PauliX; PauliI; PauliI];
+                [PauliI; PauliX; PauliI];
+                [PauliI; PauliI; PauliX]
+            ];
+    }
+
+    operation T04_CorrectErrorOnLeftQubit_Test () : () {
+        body {
+            let partialBind =
+                BindErrorCorrectionRound(Encode_Reference, _, NoOp, CorrectErrorOnLeftQubit);
+
+            let errors = PauliErrors();
+            for (idxError in 0..1) {
+                AssertOperationsEqualReferenced(partialBind(errors[idxError]), NoOp, 1);
+            }
+        }
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    // Task 05
+    //////////////////////////////////////////////////////////////////////////
+
+    operation T05_DetectErrorOnAnyQubit_Test () : () {
+        body {
+            let errors = PauliErrors();
+            using (register = Qubit[3]) {
+
+                for (idxError in 0..Length(errors) - 1) {
+                    let θ = RandomReal(12);
+                    let statePrep = BindA([H; Rz(θ, _)]);
+                    mutable errorStr = "no error";
+                    if (idxError > 0) {
+                        set errorStr = $"error on qubit {idxError}";
+                    }
+                    Message($"Testing with {errorStr}.");
+                    statePrep(Head(register));
+                    Encode_Reference(register);
+                    ApplyPauli(errors[idxError], register);
+                    AssertIntEqual(DetectErrorOnAnyQubit(register), idxError, $"Failed on state with {errorStr}.");
+                    ApplyPauli(errors[idxError], register);
+                    (Adjoint Encode_Reference)(register);
+                    (Adjoint statePrep)(Head(register));
+
+                    AssertAllZero(register);
+                }
+            }
+        }
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    // Task 06
+    //////////////////////////////////////////////////////////////////////////
+
+    operation T06_CorrectErrorOnAnyQubit_Test () : () {
+        body {
+            let partialBind =
+                BindErrorCorrectionRound(Encode_Reference, _, NoOp, CorrectErrorOnAnyQubit);
+
+            let errors = PauliErrors();
+            for (idxError in 0..Length(errors) - 1) {
+                Message($"Task 06: Testing on {errors[idxError]}...");
+                AssertOperationsEqualReferenced(partialBind(errors[idxError]), NoOp, 1);
+            }
+        }
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    // Task 07
+    //////////////////////////////////////////////////////////////////////////
+
+    operation T07_LogicalX_Test () : () {
+        body {
+            let partialBind =
+                BindErrorCorrectionRound(Encode_Reference, _, LogicalX, CorrectErrorOnAnyQubit_Reference);
+
+            let errors = PauliErrors();
+            for (idxError in 0..Length(errors) - 1) {
+                Message($"Task 07: Testing on {errors[idxError]}...");
+                AssertOperationsEqualReferenced(partialBind(errors[idxError]), ApplyPauli([PauliX], _), 1);
+            }
+        }
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    // Task 08
+    //////////////////////////////////////////////////////////////////////////
+
+    operation T08_LogicalZ_Test () : () {
+        body {
+            let partialBind =
+                BindErrorCorrectionRound(Encode_Reference, _, LogicalZ, CorrectErrorOnAnyQubit_Reference);
+
+            let errors = PauliErrors();
+            for (idxError in 0..Length(errors) - 1) {
+                Message($"Task 08: Testing on {errors[idxError]}...");
+                AssertOperationsEqualReferenced(partialBind(errors[idxError]), ApplyToEachA(Z, _), 1);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a new kata based on the [[3, 1, 1]] bit-flip code, where participants will implement a quantum error correction code that protects against any single _X_ error. Produced in collaboration with @tcNickolas.