### PR TITLE
Add CI step to check Unicode symbols used for bra and ket

### DIFF
--- a/GroversAlgorithm/ReferenceImplementation.qs
+++ b/GroversAlgorithm/ReferenceImplementation.qs
@@ -20,7 +20,7 @@ namespace Quantum.Kata.GroversAlgorithm {
     // Part I. Oracles for Grover's Search
     //////////////////////////////////////////////////////////////////
     
-    // Task 1.1. The |11...1〉 oracle
+    // Task 1.1. The |11...1⟩ oracle
     operation Oracle_AllOnes_Reference (queryRegister : Qubit[], target : Qubit) : Unit {
         
         body (...) {
@@ -31,7 +31,7 @@ namespace Quantum.Kata.GroversAlgorithm {
     }
     
     
-    // Task 1.2. The |1010...〉 oracle
+    // Task 1.2. The |1010...⟩ oracle
     operation Oracle_AlternatingBits_Reference (queryRegister : Qubit[], target : Qubit) : Unit {
         
         body (...) {
@@ -75,15 +75,15 @@ namespace Quantum.Kata.GroversAlgorithm {
         
         body (...) {
             using (target = Qubit()) {
-                // Put the target into the |-〉 state
+                // Put the target into the |-⟩ state
                 X(target);
                 H(target);
                 
-                // Apply the marking oracle; since the target is in the |-〉 state,
+                // Apply the marking oracle; since the target is in the |-⟩ state,
                 // flipping the target if the register satisfies the oracle condition will apply a -1 factor to the state
                 markingOracle(register, target);
                 
-                // Put the target back into |0〉 so we can return it
+                // Put the target back into |0⟩ so we can return it
                 H(target);
                 X(target);
             }

--- a/GroversAlgorithm/Tasks.qs
+++ b/GroversAlgorithm/Tasks.qs
@@ -33,7 +33,7 @@ namespace Quantum.Kata.GroversAlgorithm {
     // Part I. Oracles for Grover's Search
     //////////////////////////////////////////////////////////////////
     
-    // Task 1.1. The |11...1〉 oracle
+    // Task 1.1. The |11...1⟩ oracle
     // Inputs:
     //      1) N qubits in an arbitrary state |x⟩ (input/query register)
     //      2) a qubit in an arbitrary state |y⟩ (target qubit)
@@ -42,11 +42,11 @@ namespace Quantum.Kata.GroversAlgorithm {
     //       and leave it unchanged if the query register is in any other state.
     //       Leave the query register in the same state it started in.
     // Example:
-    //       If the query register is in state |00...0〉, leave the target qubit unchanged.
-    //       If the query register is in state |10...0〉, leave the target qubit unchanged.
-    //       If the query register is in state |11...1〉, flip the target qubit.
-    //       If the query register is in state (|00...0〉 + |11...1〉) / sqrt(2), and the target is in state |0〉,
-    //       the joint state of the query register and the target qubit should be (|00...00〉 + |11...11〉) / sqrt(2).
+    //       If the query register is in state |00...0⟩, leave the target qubit unchanged.
+    //       If the query register is in state |10...0⟩, leave the target qubit unchanged.
+    //       If the query register is in state |11...1⟩, flip the target qubit.
+    //       If the query register is in state (|00...0⟩ + |11...1⟩) / sqrt(2), and the target is in state |0⟩,
+    //       the joint state of the query register and the target qubit should be (|00...00⟩ + |11...11⟩) / sqrt(2).
     operation Oracle_AllOnes (queryRegister : Qubit[], target : Qubit) : Unit {
         
         body (...) {
@@ -57,7 +57,7 @@ namespace Quantum.Kata.GroversAlgorithm {
     }
     
     
-    // Task 1.2. The |1010...〉 oracle
+    // Task 1.2. The |1010...⟩ oracle
     // Inputs:
     //      1) N qubits in an arbitrary state |x⟩ (input/query register)
     //      2) a qubit in an arbitrary state |y⟩ (target qubit)
@@ -66,8 +66,8 @@ namespace Quantum.Kata.GroversAlgorithm {
     //        Leave the state of the target qubit unchanged if the query register is in any other state.
     //        Leave the query register in the same state it started in.
     // Example:
-    //        If the register is in state |0000000〉, leave the target qubit unchanged.
-    //        If the register is in state |10101〉, flip the target qubit.
+    //        If the register is in state |0000000⟩, leave the target qubit unchanged.
+    //        If the register is in state |10101⟩, flip the target qubit.
     operation Oracle_AlternatingBits (queryRegister : Qubit[], target : Qubit) : Unit {
         
         body (...) {
@@ -133,7 +133,7 @@ namespace Quantum.Kata.GroversAlgorithm {
     // Input: A register of N qubits in an arbitrary state
     // Goal:  Apply the Hadamard transform to each of the qubits in the register.
     //
-    // Note:  If the register started in the |0...0〉 state, this operation
+    // Note:  If the register started in the |0...0⟩ state, this operation
     //        will prepare an equal superposition of all 2^N basis states.
     operation HadamardTransform (register : Qubit[]) : Unit {
         
@@ -147,17 +147,17 @@ namespace Quantum.Kata.GroversAlgorithm {
     
     // Task 2.2. Conditional phase flip
     // Input: A register of N qubits in an arbitrary state.
-    // Goal:  Flip the sign of the state of the register if it is not in the |0...0〉 state.
+    // Goal:  Flip the sign of the state of the register if it is not in the |0...0⟩ state.
     // Example:
-    //        If the register is in state |0...0〉, leave it unchanged.
+    //        If the register is in state |0...0⟩, leave it unchanged.
     //        If the register is in any other basis state, multiply its phase by -1.
-    // Note: This operation implements operator 2|0...0〉⟨0...0| - I.
+    // Note: This operation implements operator 2|0...0⟩⟨0...0| - I.
     operation ConditionalPhaseFlip (register : Qubit[]) : Unit {
         
         body (...) {
             // Hint 1: Note that quantum states are defined up to a global phase.
             // Thus the state obtained as a result of this operation is the same
-            // as the state obtained by flipping the sign of only the |0...0〉 state.
+            // as the state obtained by flipping the sign of only the |0...0⟩ state.
             
             // Hint 2: You can use the same trick as in the oracle converter task.
             
@@ -196,7 +196,7 @@ namespace Quantum.Kata.GroversAlgorithm {
     
     // Task 3.1. Grover's search
     // Inputs:
-    //      1) N qubits in the |0...0〉 state,
+    //      1) N qubits in the |0...0⟩ state,
     //      2) a marking oracle, and
     //      3) the number of Grover iterations to perform.
     // Goal: Use Grover's algorithm to leave the register in the state that is marked by the oracle as the answer

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,6 +12,11 @@ variables:
   buildConfiguration: 'Release'
 
 steps:
+- task: PowerShell@2
+  inputs:
+    targetType: 'filePath'
+    filePath: 'scripts/validate-unicode.ps1'
+
 - task: NuGetToolInstaller@0
 
 - task: NuGetCommand@2

--- a/scripts/fix-unicode.ps1
+++ b/scripts/fix-unicode.ps1
@@ -1,0 +1,9 @@
+﻿$files = Select-String -Path "**\*.qs" -pattern "[〉〈]" | Select-Object -Unique Path
+
+$files | ForEach-Object {
+    # Get-Content by default reads file in UTF8 encoding
+    $Content = (Get-Content -Encoding UTF8 $_.Path) | ForEach-Object { $_ -Replace "〉", "⟩" } | ForEach-Object { $_ -replace "〈", "⟨" }
+    # Make sure the file is written without BOM
+    $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
+    [System.IO.File]::WriteAllLines($_.Path, $Content, $Utf8NoBomEncoding)
+}

--- a/scripts/validate-unicode.ps1
+++ b/scripts/validate-unicode.ps1
@@ -5,5 +5,6 @@ $lines
 # If there are any, print them and exit with an error
 if ($lines.Count -gt 0) {
     Write-Host "$("##vso[task.logissue type=error;]")Please use U+27E9 for ket symbol and U+27E8 for bra symbol"
+    Write-Host "$("##vso[task.logissue type=warning;]")You can use script /scripts/fix-unicode.ps1 to perform the replacement automatically"
     exit 1
 }

--- a/scripts/validate-unicode.ps1
+++ b/scripts/validate-unicode.ps1
@@ -4,6 +4,6 @@ $lines
 
 # If there are any, print them and exit with an error
 if ($lines.Count -gt 0) {
-    Write-Error "Please use U+27E9 for ket symbol and U+27E8 for bra symbol"
+    Write-Host "$("##vso[task.logissue type=error;]") $("Please use U+27E9 for ket symbol and U+27E8 for bra symbol")"
     exit 1
 }

--- a/scripts/validate-unicode.ps1
+++ b/scripts/validate-unicode.ps1
@@ -4,6 +4,6 @@ $lines
 
 # If there are any, print them and exit with an error
 if ($lines.Count -gt 0) {
-    Write-Host "$("##vso[task.logissue type=error;]") $("Please use U+27E9 for ket symbol and U+27E8 for bra symbol")"
+    Write-Host "$("##vso[task.logissue type=error;]")Please use U+27E9 for ket symbol and U+27E8 for bra symbol"
     exit 1
 }

--- a/scripts/validate-unicode.ps1
+++ b/scripts/validate-unicode.ps1
@@ -4,6 +4,6 @@ $lines
 
 # If there are any, print them and exit with an error
 if ($lines.Count -gt 0) {
-    Write-Host "$("##vso[task.logissue type=error;]")Please use U+27E9 for ket symbol and U+27E8 for bra symbol"
+    Write-Host "$("##vso[task.logissue type=error;]")Please use U+27E9 for ket symbol ⟩ and U+27E8 for bra symbol ⟨"
     exit 1
 }

--- a/scripts/validate-unicode.ps1
+++ b/scripts/validate-unicode.ps1
@@ -4,6 +4,6 @@ $lines
 
 # If there are any, print them and exit with an error
 if ($lines.Count -gt 0) {
-    Write-Host "$("##vso[task.logissue type=error;]")Please use U+27E9 for ket symbol ⟩ and U+27E8 for bra symbol ⟨"
+    Write-Host "$("##vso[task.logissue type=error;]")Please use U+27E9 for ket symbol and U+27E8 for bra symbol"
     exit 1
 }

--- a/scripts/validate-unicode.ps1
+++ b/scripts/validate-unicode.ps1
@@ -3,7 +3,7 @@ $lines = Select-String -Path "**\*.qs" -Pattern "[〉〈]"
 $lines
 
 # If there are any, print them and exit with an error
-if ($lines.Count > 0) {
+if ($lines.Count -gt 0) {
     Write-Error "Please use U+27E9 for ket symbol and U+27E8 for bra symbol"
     exit 1
 }

--- a/scripts/validate-unicode.ps1
+++ b/scripts/validate-unicode.ps1
@@ -1,0 +1,9 @@
+﻿# Find all lines with bad bra or ket characters
+$lines = Select-String -Path "**\*.qs" -Pattern "[〉〈]"
+$lines
+
+# If there are any, print them and exit with an error
+if ($lines.Count > 0) {
+    Write-Error "Please use U+27E9 for ket symbol and U+27E8 for bra symbol"
+    exit 1
+}


### PR DESCRIPTION
As pointed in #4, there are two symbols that can be used for each of the bra and ket notations. 
The preferred symbols to use are U+27E9 MATHEMATICAL RIGHT ANGLE BRACKET and U+27E8 MATHEMATICAL LEFT ANGLE BRACKET.

This change adds a check to prevent U+232A RIGHT-POINTING ANGLE BRACKET and U+2329 LEFT-POINTING ANGLE BRACKET from creeping back in the code. It also fixes several occurrences of these symbols in the katas.