### PR TITLE
Replace sum ⊕ with tensor product ⊗ in BasicGates kata

### DIFF
--- a/BasicGates/ReferenceImplementation.qs
+++ b/BasicGates/ReferenceImplementation.qs
@@ -162,7 +162,7 @@ namespace Quantum.Kata.BasicGates {
     // Task 2.1. Two-qubit gate - 1
     // Input: Two unentangled qubits (stored in an array of length 2).
     //     The first qubit will be in state |ψ⟩ = α |0⟩ + β |1⟩, the second - in state |0⟩
-    //     (this can be written as two-qubit state (α|0⟩ + β|1⟩) ⊕ |0⟩).
+    //     (this can be written as two-qubit state (α|0⟩ + β|1⟩) ⊗ |0⟩).
     // Goal: Change the two-qubit state to α |00⟩ + β |11⟩.
     // Note that unless the starting state of the first qubit was |0⟩ or |1⟩,
     // the resulting two-qubit state can not be represented as a tensor product
@@ -179,7 +179,7 @@ namespace Quantum.Kata.BasicGates {
     
     // Task 2.2. Two-qubit gate - 2
     // Input: Two qubits (stored in an array of length 2)
-    //        in state |+⟩ ⊕ |+⟩ = (|00⟩ + |01⟩ + |10⟩ + |11⟩) / 2.
+    //        in state |+⟩ ⊗ |+⟩ = (|00⟩ + |01⟩ + |10⟩ + |11⟩) / 2.
     // Goal: Change the two-qubit state to (|00⟩ + |01⟩ + |10⟩ - |11⟩) / 2.
     // Note that while the starting state can be represented as a tensor product of single-qubit states,
     // the resulting two-qubit state can not be represented in such a way.

--- a/BasicGates/Tasks.qs
+++ b/BasicGates/Tasks.qs
@@ -181,7 +181,7 @@ namespace Quantum.Kata.BasicGates {
     // Task 2.1. Two-qubit gate - 1
     // Input: Two unentangled qubits (stored in an array of length 2).
     //        The first qubit will be in state |ψ⟩ = α |0⟩ + β |1⟩, the second - in state |0⟩
-    //        (this can be written as two-qubit state (α|0⟩ + β|1⟩) ⊕ |0⟩).
+    //        (this can be written as two-qubit state (α|0⟩ + β|1⟩) ⊗ |0⟩).
     // Goal:  Change the two-qubit state to α |00⟩ + β |11⟩.
     // Note that unless the starting state of the first qubit was |0⟩ or |1⟩,
     // the resulting two-qubit state can not be represented as a tensor product
@@ -198,7 +198,7 @@ namespace Quantum.Kata.BasicGates {
     
     // Task 2.2. Two-qubit gate - 2
     // Input: Two qubits (stored in an array of length 2)
-    //        in state |+⟩ ⊕ |+⟩ = (|00⟩ + |01⟩ + |10⟩ + |11⟩) / 2.
+    //        in state |+⟩ ⊗ |+⟩ = (|00⟩ + |01⟩ + |10⟩ + |11⟩) / 2.
     // Goal:  Change the two-qubit state to (|00⟩ + |01⟩ + |10⟩ - |11⟩) / 2.
     // Note that while the starting state can be represented as a tensor product of single-qubit states,
     // the resulting two-qubit state can not be represented in such a way.

--- a/BasicGates/Tests.qs
+++ b/BasicGates/Tests.qs
@@ -173,7 +173,7 @@ namespace Quantum.Kata.BasicGates {
     
     
     // ------------------------------------------------------
-    // prepare state |+⟩ ⊕ |+⟩ = (|00⟩ + |01⟩ + |10⟩ + |11⟩) / 2.
+    // prepare state |+⟩ ⊗ |+⟩ = (|00⟩ + |01⟩ + |10⟩ + |11⟩) / 2.
     operation StatePrep_PlusPlus (qs : Qubit[]) : Unit {
         
         body (...) {
@@ -187,7 +187,7 @@ namespace Quantum.Kata.BasicGates {
     // ------------------------------------------------------
     operation T22_TwoQubitGate2_Test () : Unit {
         using (qs = Qubit[2]) {
-            // prepare |+⟩ ⊕ |+⟩ state
+            // prepare |+⟩ ⊗ |+⟩ state
             StatePrep_PlusPlus(qs);
             
             // apply operation that needs to be tested


### PR DESCRIPTION
In the context of describing the quantum states it should really be tensor product.