### PR TITLE
fixing reference implementation in basic gates AmplitudeChange task

### DIFF
--- a/BasicGates/ReferenceImplementation.qs
+++ b/BasicGates/ReferenceImplementation.qs
@@ -75,7 +75,7 @@ namespace Quantum.Kata.BasicGates {
     operation AmplitudeChange_Reference (q : Qubit, alpha : Double) : Unit {
         
         body (...) {
-            Ry(2.0 * alpha, q);
+            Ry(alpha + alpha, q);
         }
         
         adjoint invert;


### PR DESCRIPTION
changing "2.0 * alpha" for "alpha + alpha", as not to use Double values until the parsing problem is solved