### PR TITLE
Martinro/measurement

### DIFF
--- a/Measurements/README.md
+++ b/Measurements/README.md
@@ -10,6 +10,9 @@ Variations of quantum state discrimination tasks are covered in the paper ["Quan
   for further information and hints about how to implement the unambiguous measurements required for this task. 
 * Task 2.3 is the so-called Wootters/Peres game. See the following three references for more information and in particular
   the book [3, p. 287] for a nice description of the optimal POVM. 
+
   [1] A. Holevo, “Information-theoretical aspects of quantum measurement,” Problems of Information Transmission, vol. 9, no. 2, pp. 110–118 (1973)
+
   [2] A. Peres and W. K. Wootters, “Optimal detection of quantum information,” Phys. Rev. Lett., vol. 66, pp. 1119-1122, Mar. 1991.
+
   [3] A. Peres, “Quantum Theory: Concepts and Methods,” Kluwer Academic Publishers, 2002.

--- a/Measurements/README.md
+++ b/Measurements/README.md
@@ -8,3 +8,8 @@ Variations of quantum state discrimination tasks are covered in the paper ["Quan
 * Task 2.1 is an example of hypothesis testing for two pure states.
 * Task 2.2 is an example of unambiguous state discrimination. See also the paper ["Unambiguous quantum measurement of nonorthogonal states"](https://www.researchgate.net/publication/13375059_Unambiguous_quantum_measurement_of_nonorthogonal_states)
   for further information and hints about how to implement the unambiguous measurements required for this task. 
+* Task 2.3 is the so-called Wootters/Peres game. See the following three references for more information and in particular
+  the book [3, p. 287] for a nice description of the optimal POVM. 
+  [1] A. Holevo, “Information-theoretical aspects of quantum measurement,” Problems of Information Transmission, vol. 9, no. 2, pp. 110–118 (1973)
+  [2] A. Peres and W. K. Wootters, “Optimal detection of quantum information,” Phys. Rev. Lett., vol. 66, pp. 1119-1122, Mar. 1991.
+  [3] A. Peres, “Quantum Theory: Concepts and Methods,” Kluwer Academic Publishers, 2002.

--- a/Measurements/ReferenceImplementation.qs
+++ b/Measurements/ReferenceImplementation.qs
@@ -358,7 +358,9 @@ namespace Quantum.Kata.Measurements {
             set result = MResetZ(anc) == One ? 0 | 1;
         }
         
-        // now fix up the state so that it is identical to the input state
+        // Fix up the state so that it is identical to the input state
+        // (this is not required if the state of the qubits after the operation does not matter)
+
         // Apply state prep of 1/sqrt(3) ( |100⟩ + |010⟩ + |001⟩ )
         WState_Arbitrary_Reference(qs);
         
@@ -371,6 +373,21 @@ namespace Quantum.Kata.Measurements {
         // finally, we return the result
         return result;
     }
+
+
+    // An alternative solution to task 1.13, using a simpler measurement
+    operation ThreeQubitMeasurement_SimpleMeasurement (qs : Qubit[]) : Int {
+        // map the first state to 000 state and the second one to something orthogonal to it
+        // (as described in reference solution)
+        R1(-2.0 * PI() / 3.0, qs[1]);
+        R1(-4.0 * PI() / 3.0, qs[2]);
+        Adjoint WState_Arbitrary_Reference(qs);
+
+        // measure all qubits: if all of them are 0, we have the first state,
+        // if at least one of them is 1, we have the second state
+        return MeasureInteger(LittleEndian(qs)) == 0 ? 0 | 1;
+    }
+
     
 
     //////////////////////////////////////////////////////////////////
@@ -477,6 +494,7 @@ namespace Quantum.Kata.Measurements {
         return output;
     }
 
+
     // Task 2.3**. Unambiguous state discrimination of 3 non-orthogonal states on one qubit
     //           (a.k.a. the Peres/Wootters game)
     // Input: a qubit which is guaranteed to be in one of the three states with equal probability:
@@ -524,13 +542,13 @@ namespace Quantum.Kata.Measurements {
             let res1 = M(q);
             
             // dispatch on the cases
-            if (res0 == Zero && res1 == Zero) {
+            if (res0 == Zero and res1 == Zero) {
                 set output = 0;
             }
-            elif (res0 == One && res1 == Zero) {
+            elif (res0 == One and res1 == Zero) {
                 set output = 1;
             }
-            elif (res0 == Zero && res1 == One) {
+            elif (res0 == Zero and res1 == One) {
                 set output = 2;
             }
             else {

--- a/Measurements/ReferenceImplementation.qs
+++ b/Measurements/ReferenceImplementation.qs
@@ -477,7 +477,7 @@ namespace Quantum.Kata.Measurements {
         return output;
     }
 
-	// Task 2.3**. Unambiguous state discrimination of 3 non-orthogonal states on one qubit
+    // Task 2.3**. Unambiguous state discrimination of 3 non-orthogonal states on one qubit
     //           (a.k.a. the Peres/Wootters game)
     // Input: a qubit which is guaranteed to be in one of the three states with equal probability:
     //        |A⟩ = 1/sqrt(2) (|0⟩ + |1⟩),

--- a/Measurements/ReferenceImplementation.qs
+++ b/Measurements/ReferenceImplementation.qs
@@ -319,6 +319,60 @@ namespace Quantum.Kata.Measurements {
     }
     
     
+    
+    // Task 1.13**. Distinguish two orthogonal states on three qubits
+    operation ThreeQubitMeasurement_Reference (qs : Qubit[]) : Int {
+        
+        // We first apply a unitary operation to the input state so that it maps the first state
+        // to the W-state (see Task 10 in the "Superposition" kata) 1/sqrt(3) ( |100⟩ + |010⟩ + |001⟩ ).
+        // This can be accomplished by a tensor product of the form I₂ ⊗ R ⊗ R², where
+        //  - I₂ denotes the 2x2 identity matrix which is applied to qubit 0,
+        //  - R is the diagonal matrix diag(1, ω^-1) = diag(1, ω²) which is applied to qubit 1,
+        //  - R² = diag(1, ω) which is applied to qubit 2.
+        // Note that upon applying the operator I₂ ⊗ R ⊗ R²,
+        // the second state gets then mapped to 1/sqrt(3) ( |100⟩ + ω |010⟩ + ω² |001⟩ ).
+        //
+        // We can now perfectly distinguish these two states by invoking the inverse of the state prep
+        // routine for W-states (as in Task 10 of "Superposition") which will map the first state to the
+        // state |000⟩ and the second state to some state which is guaranteed to be perpendicular to
+        // the state |000⟩, i.e., the second state gets mapped to a superposition that does not involve
+        // |000⟩. Now, the two states can be perfectly distinguished (while leaving them intact) by
+        // attaching an ancilla qubit, computing the OR function of the three bits (which can be
+        // accomplished using a multiply-controlled X gate with inverted inputs) and measuring said
+        // ancilla qubit.
+        mutable result = 0;
+        
+        // rotate qubit 1 by angle - 2π/3 around z-axis
+        Rz((4.0 * PI()) / 3.0, qs[1]);
+        
+        // rotate qubit 2 by angle - 4π/3 around z-axis
+        Rz((8.0 * PI()) / 3.0, qs[2]);
+        
+        // Apply inverse state prep of 1/sqrt(3) ( |100⟩ + |010⟩ + |001⟩ )
+        Adjoint WState_Arbitrary_Reference(qs);
+        
+        // need one qubit to store result of comparison "000" vs "not 000"
+        using (anc = Qubit()) {
+            // compute the OR function into anc
+            (ControlledOnInt(0, X))(qs, anc);
+            set result = MResetZ(anc) == One ? 0 | 1;
+        }
+        
+        // now fix up the state so that it is identical to the input state
+        // Apply state prep of 1/sqrt(3) ( |100⟩ + |010⟩ + |001⟩ )
+        WState_Arbitrary_Reference(qs);
+        
+        // rotate qubit 1 by angle 2π/3 around z-axis
+        Rz((-4.0 * PI()) / 3.0, qs[1]);
+        
+        // rotate qubit 2 by angle 4π/3 around z-axis
+        Rz((-8.0 * PI()) / 3.0, qs[2]);
+        
+        // finally, we return the result
+        return result;
+    }
+    
+
     //////////////////////////////////////////////////////////////////
     // Part II*. Discriminating Nonorthogonal States
     //////////////////////////////////////////////////////////////////
@@ -422,5 +476,69 @@ namespace Quantum.Kata.Measurements {
         
         return output;
     }
-    
+
+	// Task 2.3**. Unambiguous state discrimination of 3 non-orthogonal states on one qubit
+    //           (a.k.a. the Peres/Wootters game)
+    // Input: a qubit which is guaranteed to be in one of the three states with equal probability:
+    //        |A⟩ = 1/sqrt(2) (|0⟩ + |1⟩),
+    //        |B⟩ = 1/sqrt(2) (|0⟩ + ω |1⟩),
+    //        |C⟩ = 1/sqrt(2) (|0⟩ + ω² |1⟩).
+    //	      where ω = exp(2π/3) denotes a primitive, complex 3rd root of unity.
+    // Output: 1 or 2 if qubit was in the |A⟩ state,
+    //         0 or 2 if qubit was in the |B⟩ state,
+    //         0 or 1 if qubit was in the |C⟩ state.
+    // The state of the qubit at the end of the operation does not matter.
+    // Note: in this task you have to succeed with probability 1, i.e., your are never allowed
+    //       to give an incorrect answer.
+    operation IsQubitNotInABC_Reference (q : Qubit) : Int {
+        
+        // The key is the observation that the POVM with rank one elements {E_0, E_1, E_2} will do
+        // the job, where E_k = |psi_k><psi_k| and |psi_k⟩ = 1/sqrt(2)(|0⟩-ω^k |1⟩) and where
+        // k = 0, 1, 2. The remaining task will be to find a von Neumann measurement (on a qubit
+        // system) that implements said POVM by means of a quantum circuit. To obtain such a
+        // quantum circuit, we observe that all we need is a unitary extension of the matrix
+        // formed by A = (psi_0, psi_1, psi_2). In general, such a unitary extension can be
+        // found using a Singular Value Decomposition of the matrix. Here we can apply a short cut:
+        // The matrix A can be extended (up to a +1/-1 diagonal) to a 3x3 Discrete Fourier Transform.
+        // Padded with 1 extra dimension (i.e., a 1x1 block in which we have phase freedom), we obtain
+        // a 4x4 unitary. Using the "Rader trick" we can now block decompose the 3x3 DFT and obtain two
+        // 2x2 blocks which we can then implement using controlled single qubit gates. We present
+        // the final resulting circuit without additional commentary.
+        mutable output = 0;
+        let alpha = ArcCos(Sqrt(2.0 / 3.0));
+        
+        using (a = Qubit()) {
+            Z(q);
+            CNOT(a, q);
+            Controlled H([q], a);
+            S(a);
+            X(q);
+
+            (ControlledOnInt(0, Ry))([a], (-2.0 * alpha, q));
+            CNOT(a, q);
+            Controlled H([q], a);
+            CNOT(a, q);
+            
+            // finally, measure in the standard basis
+            let res0 = MResetZ(a);
+            let res1 = M(q);
+            
+            // dispatch on the cases
+            if (res0 == Zero && res1 == Zero) {
+                set output = 0;
+            }
+            elif (res0 == One && res1 == Zero) {
+                set output = 1;
+            }
+            elif (res0 == Zero && res1 == One) {
+                set output = 2;
+            }
+            else {
+                // this should never occur
+                set output = 3;
+            }
+        }
+        
+        return output;
+    }  
 }

--- a/Measurements/Tasks.qs
+++ b/Measurements/Tasks.qs
@@ -207,6 +207,20 @@ namespace Quantum.Kata.Measurements {
     }
     
     
+    // Task 1.13**. Distinguish two orthogonal states on three qubits
+    // Input: Three qubits (stored in an array) which are guaranteed to be in either one of the
+    //        following two states: (where ω = exp(2π i/3) denotes a primitive 3rd root of unity):
+    //        1/sqrt(3) ( |100⟩ + ω |010⟩ + ω² |001⟩ ),
+    //        1/sqrt(3) ( |100⟩ + ω² |010⟩ + ω |001⟩ ).
+    // Output: 0 if qubits were in the first superposition,
+    //         1 if they were in the second superposition.
+    // The state of the qubits at the end of the operation should be the same as the starting state.
+    operation ThreeQubitMeasurement (qs : Qubit[]) : Int {
+        // ...
+        return -1;
+    }
+    
+    
     //////////////////////////////////////////////////////////////////
     // Part II*. Discriminating Nonorthogonal States
     //////////////////////////////////////////////////////////////////
@@ -247,5 +261,23 @@ namespace Quantum.Kata.Measurements {
         // ...
         return -2;
     }
+
     
+    // Task 2.3**. Unambiguous state discrimination of 3 non-orthogonal states on one qubit
+    //           (a.k.a. the Peres/Wootters game)
+    // Input: a qubit which is guaranteed to be in one of the three states with equal probability:
+    //        |A⟩ = 1/sqrt(2) (|0⟩ + |1⟩),
+    //        |B⟩ = 1/sqrt(2) (|0⟩ + ω |1⟩),
+    //        |C⟩ = 1/sqrt(2) (|0⟩ + ω² |1⟩).
+    //	      where ω = exp(2iπ/3) denotes a primitive, complex 3rd root of unity.
+    // Output: 1 or 2 if qubit was in the |A⟩ state,
+    //         0 or 2 if qubit was in the |B⟩ state,
+    //         0 or 1 if qubit was in the |C⟩ state.
+    // The state of the qubit at the end of the operation does not matter.
+    // Note: in this task you have to succeed with probability 1, i.e., your are never allowed
+    //       to give an incorrect answer.
+    operation IsQubitNotInABC (q : Qubit) : Int {
+        // ...
+        return -1;
+    }
 }

--- a/Measurements/Tasks.qs
+++ b/Measurements/Tasks.qs
@@ -214,7 +214,7 @@ namespace Quantum.Kata.Measurements {
     //        1/sqrt(3) ( |100⟩ + ω² |010⟩ + ω |001⟩ ).
     // Output: 0 if qubits were in the first superposition,
     //         1 if they were in the second superposition.
-    // The state of the qubits at the end of the operation should be the same as the starting state.
+    // The state of the qubits at the end of the operation does not matter.
     operation ThreeQubitMeasurement (qs : Qubit[]) : Int {
         // ...
         return -1;
@@ -264,17 +264,17 @@ namespace Quantum.Kata.Measurements {
 
     
     // Task 2.3**. Unambiguous state discrimination of 3 non-orthogonal states on one qubit
-    //           (a.k.a. the Peres/Wootters game)
+    //             (a.k.a. the Peres/Wootters game)
     // Input: a qubit which is guaranteed to be in one of the three states with equal probability:
     //        |A⟩ = 1/sqrt(2) (|0⟩ + |1⟩),
     //        |B⟩ = 1/sqrt(2) (|0⟩ + ω |1⟩),
-    //        |C⟩ = 1/sqrt(2) (|0⟩ + ω² |1⟩).
+    //        |C⟩ = 1/sqrt(2) (|0⟩ + ω² |1⟩),
     //	      where ω = exp(2iπ/3) denotes a primitive, complex 3rd root of unity.
     // Output: 1 or 2 if qubit was in the |A⟩ state,
     //         0 or 2 if qubit was in the |B⟩ state,
     //         0 or 1 if qubit was in the |C⟩ state.
     // The state of the qubit at the end of the operation does not matter.
-    // Note: in this task you have to succeed with probability 1, i.e., your are never allowed
+    // Note: in this task you have to succeed with probability 1, i.e., you are never allowed
     //       to give an incorrect answer.
     operation IsQubitNotInABC (q : Qubit) : Int {
         // ...

--- a/Measurements/Tests.qs
+++ b/Measurements/Tests.qs
@@ -540,7 +540,7 @@ namespace Quantum.Kata.Measurements {
         USD_DistinguishStates_MultiQubit_Threshold(1, 2, 0.8, 0.1, StatePrep_IsQubitZeroOrPlus, IsQubitPlusZeroOrInconclusiveSimpleUSD);
     }
     
-	
+    
     // ------------------------------------------------------
     operation StatePrep_IsQubitNotInABC (q : Qubit, state : Int) : Unit {
         let alpha = (2.0 * PI()) / 3.0;

--- a/Measurements/Tests.qs
+++ b/Measurements/Tests.qs
@@ -581,7 +581,7 @@ namespace Quantum.Kata.Measurements {
                 let ans = testImpl(qs[0]);
                 
                 // check that the value of ans is 0, 1 or 2
-                if (ans < 0 || ans > 2) {
+                if (ans < 0 or ans > 2) {
                     fail "You can not return any value other than 0, 1 or 2.";
                 }
                 
@@ -596,9 +596,7 @@ namespace Quantum.Kata.Measurements {
         }
     }
     
-    operation T202_IsQubitNotInABC_Test () : Unit {
+    operation T203_IsQubitNotInABC_Test () : Unit {
         ABC_DistinguishStates_MultiQubit_Threshold(1, 3, StatePrep_IsQubitNotInABC, IsQubitNotInABC);
     }
-    
-
 }


### PR DESCRIPTION
Task 1.13**. Distinguish two orthogonal states on three qubits
Task 2.3**. Unambiguous state discrimination of 3 non-orthogonal states on one qubit

Updating ReferenceImplementation.qs, Tasks.qs, Tests.qs, and README.md