### PR TITLE
Convert Measurements kata to Notebook format

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,5 +59,8 @@ RUN jupyter nbconvert BasicGates/BasicGates.ipynb --execute --stdout --to markdo
 RUN dotnet build Superposition
 RUN jupyter nbconvert Superposition/Superposition.ipynb --execute --stdout --to markdown  --allow-errors  --ExecutePreprocessor.timeout=120
 
+RUN dotnet build Measurements
+RUN jupyter nbconvert Measurements/Measurements.ipynb --execute --stdout --to markdown  --allow-errors  --ExecutePreprocessor.timeout=120
+
 RUN dotnet build DeutschJozsaAlgorithm
 RUN jupyter nbconvert DeutschJozsaAlgorithm/DeutschJozsaAlgorithm.ipynb --execute --stdout --to markdown  --allow-errors  --ExecutePreprocessor.timeout=120

--- a/Measurements/Measurements.csproj
+++ b/Measurements/Measurements.csproj
@@ -19,4 +19,8 @@
   <ItemGroup>
     <None Include="README.md" />
   </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\utilities\Common\Common.csproj" />
+  </ItemGroup>
 </Project>

--- a/Measurements/Measurements.ipynb
+++ b/Measurements/Measurements.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Measurements Kata\n",
     "\n",
-    "**Measurements** quantum kata is a series of exercises designed\n",
+    "The **Measurements** quantum kata is a series of exercises designed\n",
     "to get you familiar with the concept of measurements and with programming in Q#.\n",
     "It covers the following topics:\n",
     "* single-qubit measurements,\n",
@@ -57,7 +57,7 @@
    "source": [
     "### Task 1.1. $|0\\rangle$ or $|1\\rangle$?\n",
     "\n",
-    "**Input:** A qubit which is guaranteed to be in $|0\\rangle$ or $|1\\rangle$ state.\n",
+    "**Input:** A qubit which is guaranteed to be in either the $|0\\rangle$ or the $|1\\rangle$ state.\n",
     "\n",
     "**Output:**  `true` if the qubit was in the $|1\\rangle$ state, or `false` if it was in the $|0\\rangle$ state. The state of the qubit at the end of the operation does not matter."
    ]
@@ -113,7 +113,7 @@
    "source": [
     "### Task 1.3. $|+\\rangle$ or $|-\\rangle$?\n",
     "\n",
-    "**Input:** A qubit which is guaranteed to be in $|+\\rangle$ or $|-\\rangle$ state. As a reminder, $|+\\rangle = \\frac{1}{\\sqrt{2}} \\big(|0\\rangle + |1\\rangle\\big)$, $|-\\rangle = \\frac{1}{\\sqrt{2}} \\big(|0\\rangle - |1\\rangle\\big)$.\n",
+    "**Input:** A qubit which is guaranteed to be in either the $|+\\rangle$ or the $|-\\rangle$ state. As a reminder, $|+\\rangle = \\frac{1}{\\sqrt{2}} \\big(|0\\rangle + |1\\rangle\\big)$, $|-\\rangle = \\frac{1}{\\sqrt{2}} \\big(|0\\rangle - |1\\rangle\\big)$.\n",
     "\n",
     "**Output:** `true` if the qubit was in the $|+\\rangle$ state, or `false` if it was in the $|-\\rangle$ state. The state of the qubit at the end of the operation does not matter."
    ]
@@ -140,7 +140,7 @@
     "**Inputs:** \n",
     "\n",
     "1. Angle $\\alpha$, in radians, represented as a `Double`.\n",
-    "2. A qubit which is guaranteed to be in $|A\\rangle$ or $|B\\rangle$ state, where $|A\\rangle = \\cos \\alpha |0\\rangle + \\sin \\alpha |1\\rangle$ and $|B\\rangle = - \\sin \\alpha |0\\rangle + \\cos \\alpha |1\\rangle$.\n",
+    "2. A qubit which is guaranteed to be in either the $|A\\rangle$ or the $|B\\rangle$ state, where $|A\\rangle = \\cos \\alpha |0\\rangle + \\sin \\alpha |1\\rangle$ and $|B\\rangle = - \\sin \\alpha |0\\rangle + \\cos \\alpha |1\\rangle$.\n",
     "\n",
     "**Output:** `true` if the qubit was in the $|A\\rangle$ state, or `false` if it was in the $|B\\rangle$ state. The state of the qubit at the end of the operation does not matter."
    ]
@@ -153,7 +153,7 @@
    "source": [
     "%kata T104_IsQubitA_Test\n",
     "\n",
-    "operation IsQubitA (α : Double, q : Qubit) : Bool {\n",
+    "operation IsQubitA (alpha : Double, q : Qubit) : Bool {\n",
     "    // ...\n",
     "}"
    ]
@@ -164,7 +164,7 @@
    "source": [
     "### Task 1.5. $|00\\rangle$ or $|11\\rangle$?\n",
     "\n",
-    "**Input:** Two qubits (stored in an array of length 2) which are guaranteed to be in the $|00\\rangle$ or in the $|11\\rangle$ state.\n",
+    "**Input:** Two qubits (stored in an array of length 2) which are guaranteed to be in either the $|00\\rangle$ or the $|11\\rangle$ state.\n",
     "\n",
     "**Output:** 0 if the qubits were in the $|00\\rangle$ state, or 1 if they were in the $|11\\rangle$ state. The state of the qubits at the end of the operation does not matter."
    ]
@@ -446,7 +446,7 @@
    "source": [
     "### Task 2.1*. $|0\\rangle$ or $|+\\rangle$?\n",
     "\n",
-    "**Input:** A qubit which is guaranteed to be in $|0\\rangle$ or $|+\\rangle$ state.\n",
+    "**Input:** A qubit which is guaranteed to be in either the $|0\\rangle$ or the $|+\\rangle$ state.\n",
     "\n",
     "**Output:**  `true` if the qubit was in the $|0\\rangle$ state, or `false` if it was in the $|+\\rangle$ state. The state of the qubit at the end of the operation does not matter.\n",
     "\n",
@@ -474,7 +474,7 @@
    "source": [
     "### Task 2.2**. $|0\\rangle$, $|+\\rangle$ or inconclusive?\n",
     "\n",
-    "**Input:** A qubit which is guaranteed to be in $|0\\rangle$ or $|+\\rangle$ state.\n",
+    "**Input:** A qubit which is guaranteed to be in either the $|0\\rangle$ or the $|+\\rangle$ state.\n",
     "\n",
     "**Output:** \n",
     "\n",
@@ -486,9 +486,9 @@
     "\n",
     "* should never give 0 or 1 answer incorrectly (i.e., identify $|0\\rangle$ as 1 or $|+\\rangle$ as 0),\n",
     "* will be called multiple times, with one of the states picked with equal probability every time,\n",
-    "* is allowed to give inconclusive (-1) answer in at most 80% of all the cases,\n",
-    "* must correctly identify $|0\\rangle$ state as 0 in at least 10% of all the cases,\n",
-    "* must correctly identify $|1\\rangle$ state as 1 in at least 10% of all the cases.\n",
+    "* may give inconclusive (-1) answer in at most 80% of all the cases,\n",
+    "* must correctly identify the $|0\\rangle$ state as 0 in at least 10% of all the cases,\n",
+    "* must correctly identify the $|1\\rangle$ state as 1 in at least 10% of all the cases.\n",
     "\n",
     "The state of the qubit at the end of the operation does not matter.\n",
     "\n",

--- a/Measurements/Measurements.ipynb
+++ b/Measurements/Measurements.ipynb
@@ -1,0 +1,571 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Measurements Kata\n",
+    "\n",
+    "**Measurements** quantum kata is a series of exercises designed\n",
+    "to get you familiar with the concept of measurements and with programming in Q#.\n",
+    "It covers the following topics:\n",
+    "* single-qubit measurements,\n",
+    "* discriminating orthogonal and nonorthogonal states.\n",
+    "\n",
+    "Each task is wrapped in one operation preceded by the description of the task.\n",
+    "Your goal is to fill in the blank (marked with // ... comment)\n",
+    "with some Q# code that solves the task. To verify your answer, run the cell using Ctrl/⌘+Enter.\n",
+    "\n",
+    "The tasks are given in approximate order of increasing difficulty; harder ones are marked with asterisks."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To begin, first prepare this notebook for execution (if you skip the first step, you'll get \"Syntax does not match any known patterns\" error when you try to execute Q# code in the next cells; if you skip the second step, you'll get \"Invalid kata name\" error):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%package Microsoft.Quantum.Katas"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%workspace reload"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Part I. Discriminating Orthogonal States"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Task 1.1. $|0\\rangle$ or $|1\\rangle$?\n",
+    "\n",
+    "**Input:** A qubit which is guaranteed to be in $|0\\rangle$ or $|1\\rangle$ state.\n",
+    "\n",
+    "**Output:**  `true` if the qubit was in the $|1\\rangle$ state, or `false` if it was in the $|0\\rangle$ state. The state of the qubit at the end of the operation does not matter."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%kata T101_IsQubitOne_Test \n",
+    "\n",
+    "operation IsQubitOne (q : Qubit) : Bool {\n",
+    "    // The operation M will measure a qubit in the Z basis (|0⟩ and |1⟩ basis)\n",
+    "    // and return Zero if the observed state was |0⟩ or One if the state was |1⟩.\n",
+    "    // To answer the question, you need to perform the measurement and check whether the result\n",
+    "    // equals One - either directly or using library function IsResultOne.\n",
+    "    //\n",
+    "    // Type the following: return M(q) == One;\n",
+    "    // Then run the cell using Ctrl/⌘+Enter.\n",
+    "\n",
+    "    // ...\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Task 1.2. Set the qubit to the $|0\\rangle$ state.\n",
+    "\n",
+    "**Input:** A qubit in an arbitrary state.\n",
+    "\n",
+    "**Goal:**  Change the state of the qubit to $|0\\rangle$."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%kata T102_InitializeQubit_Test \n",
+    "\n",
+    "operation InitializeQubit (q : Qubit) : Unit {\n",
+    "    // ...\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Task 1.3. $|+\\rangle$ or $|-\\rangle$?\n",
+    "\n",
+    "**Input:** A qubit which is guaranteed to be in $|+\\rangle$ or $|-\\rangle$ state. As a reminder, $|+\\rangle = \\frac{1}{\\sqrt{2}} \\big(|0\\rangle + |1\\rangle\\big)$, $|-\\rangle = \\frac{1}{\\sqrt{2}} \\big(|0\\rangle - |1\\rangle\\big)$.\n",
+    "\n",
+    "**Output:** `true` if the qubit was in the $|+\\rangle$ state, or `false` if it was in the $|-\\rangle$ state. The state of the qubit at the end of the operation does not matter."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%kata T103_IsQubitPlus_Test \n",
+    "\n",
+    "operation IsQubitPlus (q : Qubit) : Bool {\n",
+    "    // ...\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Task 1.4. $|A\\rangle$ or $|B\\rangle$?\n",
+    "\n",
+    "**Inputs:** \n",
+    "\n",
+    "1. Angle $\\alpha$, in radians, represented as a `Double`.\n",
+    "2. A qubit which is guaranteed to be in $|A\\rangle$ or $|B\\rangle$ state, where $|A\\rangle = \\cos \\alpha |0\\rangle + \\sin \\alpha |1\\rangle$ and $|B\\rangle = - \\sin \\alpha |0\\rangle + \\cos \\alpha |1\\rangle$.\n",
+    "\n",
+    "**Output:** `true` if the qubit was in the $|A\\rangle$ state, or `false` if it was in the $|B\\rangle$ state. The state of the qubit at the end of the operation does not matter."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%kata T104_IsQubitA_Test\n",
+    "\n",
+    "operation IsQubitA (α : Double, q : Qubit) : Bool {\n",
+    "    // ...\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Task 1.5. $|00\\rangle$ or $|11\\rangle$?\n",
+    "\n",
+    "**Input:** Two qubits (stored in an array of length 2) which are guaranteed to be in the $|00\\rangle$ or in the $|11\\rangle$ state.\n",
+    "\n",
+    "**Output:** 0 if the qubits were in the $|00\\rangle$ state, or 1 if they were in the $|11\\rangle$ state. The state of the qubits at the end of the operation does not matter."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%kata T105_ZeroZeroOrOneOne_Test\n",
+    "\n",
+    "operation ZeroZeroOrOneOne (qs : Qubit[]) : Int {\n",
+    "    // ...\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Task 1.6. Distinguish four basis states.\n",
+    "\n",
+    "**Input:** Two qubits (stored in an array of length 2) which are guaranteed to be in one of the four basis states ($|00\\rangle$, $|01\\rangle$, $|10\\rangle$, or $|11\\rangle$).\n",
+    "\n",
+    "**Output:**\n",
+    "\n",
+    "* 0 if the qubits were in the $|00\\rangle$ state,\n",
+    "* 1 if they were in the $|01\\rangle$ state, \n",
+    "* 2 if they were in the $|10\\rangle$ state, \n",
+    "* 3 if they were in the $|11\\rangle$ state.\n",
+    "\n",
+    "In this task and the subsequent ones the order of qubit states in task description matches the order of qubits in the array (i.e., $|10\\rangle$ state corresponds to `qs[0]` in state $|1\\rangle$ and `qs[1]` in state $|0\\rangle$).\n",
+    "\n",
+    "The state of the qubits at the end of the operation does not matter."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%kata T106_BasisStateMeasurement_Test\n",
+    "\n",
+    "operation BasisStateMeasurement (qs : Qubit[]) : Int {\n",
+    "    // ...\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Task 1.7. Distinguish two basis states given by bit strings\n",
+    "\n",
+    "**Inputs:** \n",
+    "\n",
+    "1. $N$ qubits (stored in an array of length $N$) which are guaranteed to be in one of the two basis states described by the given bit strings.\n",
+    "2. Two bit strings represented as `Bool[]`s.\n",
+    "\n",
+    "**Output:** \n",
+    "\n",
+    "* 0 if the qubits were in the basis state described by the first bit string,\n",
+    "* 1 if they were in the basis state described by the second bit string.\n",
+    "\n",
+    "Bit values `false` and `true` correspond to $|0\\rangle$ and $|1\\rangle$ states. You are guaranteed that both bit strings have the same length as the qubit array, and that the bit strings differ in at least one bit.\n",
+    "\n",
+    "You can use exactly one measurement. The state of the qubits at the end of the operation does not matter.\n",
+    "\n",
+    "> Example:  for bit strings `[false, true, false]` and `[false, false, true]` return 0 corresponds to state $|010\\rangle$, and return 1 corresponds to state $|001\\rangle$."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%kata T107_TwoBitstringsMeasurement_Test\n",
+    "\n",
+    "operation TwoBitstringsMeasurement (qs : Qubit[], bits1 : Bool[], bits2 : Bool[]) : Int {\n",
+    "    // ...\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Task 1.8. $|0...0\\rangle$ state or W state ?\n",
+    "\n",
+    "**Input:** $N$ qubits (stored in an array of length $N$) which are guaranteed to be either in the $|0...0\\rangle$ state or in the [W state](https://en.wikipedia.org/wiki/W_state). \n",
+    "\n",
+    "**Output:**\n",
+    "\n",
+    "* 0 if the qubits were in the $|0...0\\rangle$ state,\n",
+    "* 1 if they were in the W state.\n",
+    "\n",
+    "The state of the qubits at the end of the operation does not matter."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%kata T108_AllZerosOrWState_Test\n",
+    "\n",
+    "operation AllZerosOrWState (qs : Qubit[]) : Int {\n",
+    "    // ...\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Task 1.9. GHZ state or W state ?\n",
+    "\n",
+    "**Input:** $N \\ge 2$ qubits (stored in an array of length $N$) which are guaranteed to be either in the [GHZ state](https://en.wikipedia.org/wiki/Greenberger%E2%80%93Horne%E2%80%93Zeilinger_state) or in the [W state](https://en.wikipedia.org/wiki/W_state).\n",
+    "\n",
+    "**Output:** \n",
+    "\n",
+    "* 0 if the qubits were in the GHZ state,\n",
+    "* 1 if they were in the W state.\n",
+    "\n",
+    "The state of the qubits at the end of the operation does not matter."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%kata T109_GHZOrWState_Test\n",
+    "\n",
+    "operation GHZOrWState (qs : Qubit[]) : Int {\n",
+    "    // ...\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Task 1.10. Distinguish four Bell states.\n",
+    "\n",
+    "**Input:** Two qubits (stored in an array of length 2) which are guaranteed to be in one of the four Bell states.\n",
+    "\n",
+    "**Output:**\n",
+    "\n",
+    "* 0 if they were in the state $|\\Phi^{+}\\rangle = \\frac{1}{\\sqrt{2}} \\big (|00\\rangle + |11\\rangle\\big)$,\n",
+    "* 1 if they were in the state $|\\Phi^{-}\\rangle = \\frac{1}{\\sqrt{2}} \\big (|00\\rangle - |11\\rangle\\big)$,\n",
+    "* 2 if they were in the state $|\\Psi^{+}\\rangle = \\frac{1}{\\sqrt{2}} \\big (|01\\rangle + |10\\rangle\\big)$,\n",
+    "* 3 if they were in the state $|\\Psi^{-}\\rangle = \\frac{1}{\\sqrt{2}} \\big (|01\\rangle - |10\\rangle\\big)$.\n",
+    "\n",
+    "The state of the qubits at the end of the operation does not matter."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%kata T110_BellState_Test\n",
+    "\n",
+    "operation BellState (qs : Qubit[]) : Int {\n",
+    "    // ...\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Task 1.11. Distinguish four orthogonal 2-qubit states.\n",
+    "\n",
+    "**Input:** Two qubits (stored in an array of length 2) which are guaranteed to be in one of the four orthogonal states.\n",
+    "\n",
+    "**Output:**\n",
+    "\n",
+    "* 0 if they were in the state $|S_0\\rangle = \\frac{1}{2} \\big (|00\\rangle + |01\\rangle + |10\\rangle + |11\\rangle\\big)$,\n",
+    "* 1 if they were in the state $|S_1\\rangle = \\frac{1}{2} \\big (|00\\rangle - |01\\rangle + |10\\rangle - |11\\rangle\\big)$,\n",
+    "* 2 if they were in the state $|S_2\\rangle = \\frac{1}{2} \\big (|00\\rangle + |01\\rangle - |10\\rangle - |11\\rangle\\big)$,\n",
+    "* 3 if they were in the state $|S_3\\rangle = \\frac{1}{2} \\big (|00\\rangle - |01\\rangle - |10\\rangle + |11\\rangle\\big)$.\n",
+    "\n",
+    "The state of the qubits at the end of the operation does not matter."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%kata T111_TwoQubitState_Test\n",
+    "\n",
+    "operation TwoQubitState (qs : Qubit[]) : Int {\n",
+    "    // ...\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Task 1.12*. Distinguish four orthogonal 2-qubit states, part 2.\n",
+    "\n",
+    "**Input:** Two qubits (stored in an array of length 2) which are guaranteed to be in one of the four orthogonal states.\n",
+    "\n",
+    "**Output:**\n",
+    "\n",
+    "* 0 if they were in the state $|S_0\\rangle = \\frac{1}{2} \\big (+ |00\\rangle - |01\\rangle - |10\\rangle - |11\\rangle\\big)$,\n",
+    "* 1 if they were in the state $|S_1\\rangle = \\frac{1}{2} \\big (- |00\\rangle + |01\\rangle - |10\\rangle - |11\\rangle\\big)$,\n",
+    "* 2 if they were in the state $|S_2\\rangle = \\frac{1}{2} \\big (- |00\\rangle - |01\\rangle + |10\\rangle - |11\\rangle\\big)$,\n",
+    "* 3 if they were in the state $|S_3\\rangle = \\frac{1}{2} \\big (- |00\\rangle - |01\\rangle - |10\\rangle + |11\\rangle\\big)$.\n",
+    "\n",
+    "The state of the qubits at the end of the operation does not matter."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%kata T112_TwoQubitStatePartTwo_Test\n",
+    "\n",
+    "operation TwoQubitStatePartTwo (qs : Qubit[]) : Int {\n",
+    "    // ...\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Task 1.13**. Distinguish two orthogonal states on three qubits.\n",
+    "\n",
+    "**Input:** Three qubits (stored in an array of length 3) which are guaranteed to be in one of the two orthogonal states.\n",
+    "\n",
+    "**Output:**\n",
+    "\n",
+    "* 0 if they were in the state $|S_0\\rangle = \\frac{1}{\\sqrt{3}} \\big (|100\\rangle + \\omega |010\\rangle + \\omega^2 |001\\rangle)$,\n",
+    "* 1 if they were in the state $|S_1\\rangle = \\frac{1}{\\sqrt{3}} \\big (|100\\rangle + \\omega^2 |010\\rangle + \\omega |001\\rangle)$.\n",
+    "\n",
+    "Here $\\omega = e^{2i \\pi/ 3}$.\n",
+    "\n",
+    "The state of the qubits at the end of the operation does not matter."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%kata T113_ThreeQubitMeasurement_Test\n",
+    "\n",
+    "operation ThreeQubitMeasurement (qs : Qubit[]) : Int {\n",
+    "    // ...\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Part II*. Discriminating Nonorthogonal States"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Task 2.1*. $|0\\rangle$ or $|+\\rangle$?\n",
+    "\n",
+    "**Input:** A qubit which is guaranteed to be in $|0\\rangle$ or $|+\\rangle$ state.\n",
+    "\n",
+    "**Output:**  `true` if the qubit was in the $|0\\rangle$ state, or `false` if it was in the $|+\\rangle$ state. The state of the qubit at the end of the operation does not matter.\n",
+    "\n",
+    "In this task your solution will be called multiple times, with one of the states picked with equal probability every time. You have to get overall accuracy of at least 80%.\n",
+    "\n",
+    "This task is an example of quantum hypothesis testing, or state discrimination with minimum error."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%kata T201_IsQubitZeroOrPlus_Test\n",
+    "\n",
+    "operation IsQubitPlusOrZero (q : Qubit) : Bool {\n",
+    "    // ...\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Task 2.2**. $|0\\rangle$, $|+\\rangle$ or inconclusive?\n",
+    "\n",
+    "**Input:** A qubit which is guaranteed to be in $|0\\rangle$ or $|+\\rangle$ state.\n",
+    "\n",
+    "**Output:** \n",
+    "\n",
+    "* 0 if the qubit was in the $|0\\rangle$ state, \n",
+    "* 1 if it was in the $|+\\rangle$ state,\n",
+    "* -1 if you can't decide, i.e., an \"inconclusive\" result. \n",
+    "\n",
+    "Your solution:\n",
+    "\n",
+    "* should never give 0 or 1 answer incorrectly (i.e., identify $|0\\rangle$ as 1 or $|+\\rangle$ as 0),\n",
+    "* will be called multiple times, with one of the states picked with equal probability every time,\n",
+    "* is allowed to give inconclusive (-1) answer in at most 80% of all the cases,\n",
+    "* must correctly identify $|0\\rangle$ state as 0 in at least 10% of all the cases,\n",
+    "* must correctly identify $|1\\rangle$ state as 1 in at least 10% of all the cases.\n",
+    "\n",
+    "The state of the qubit at the end of the operation does not matter.\n",
+    "\n",
+    "This task is an example of unambiguous state discrimination.\n",
+    "\n",
+    "<br/>\n",
+    "<details>\n",
+    "  <summary>Need a hint? Click here</summary>\n",
+    "  You can use extra qubit(s) is your solution.\n",
+    "</details>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%kata T202_IsQubitZeroOrPlusSimpleUSD_Test\n",
+    "\n",
+    "operation IsQubitPlusZeroOrInconclusiveSimpleUSD (q : Qubit) : Int {\n",
+    "    // ...\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Task 2.3**.  Peres/Wooters game\n",
+    "\n",
+    "**Input:** A qubit which is guaranteed to be in one of the three states:\n",
+    "\n",
+    "* $|A\\rangle = \\frac{1}{\\sqrt{2}} \\big( |0\\rangle + |1\\rangle \\big)$,\n",
+    "* $|B\\rangle = \\frac{1}{\\sqrt{2}} \\big( |0\\rangle + \\omega |1\\rangle \\big)$,\n",
+    "* $|C\\rangle = \\frac{1}{\\sqrt{2}} \\big( |0\\rangle + \\omega^2 |1\\rangle \\big)$,\n",
+    "\n",
+    "Here $\\omega = e^{2i \\pi/ 3}$.\n",
+    "\n",
+    "**Output:** \n",
+    "\n",
+    "* 1 or 2 if the qubit was in the $|A\\rangle$ state, \n",
+    "* 0 or 2 if the qubit was in the $|B\\rangle$ state, \n",
+    "* 0 or 1 if the qubit was in the $|C\\rangle$ state.\n",
+    "\n",
+    "You are never allowed to give an incorrect answer. Your solution will be called multiple times, with one of the states picked with equal probability every time.\n",
+    "\n",
+    "The state of the qubit at the end of the operation does not matter. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%kata T203_IsQubitNotInABC_Test\n",
+    "\n",
+    "operation IsQubitNotInABC (q : Qubit) : Int {\n",
+    "    // ...\n",
+    "}"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Q#",
+   "language": "qsharp",
+   "name": "iqsharp"
+  },
+  "language_info": {
+   "file_extension": ".qs",
+   "mimetype": "text/x-qsharp",
+   "name": "qsharp",
+   "version": "0.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/Measurements/Measurements.sln
+++ b/Measurements/Measurements.sln
@@ -3,7 +3,9 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.27130.2036
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Measurements", "Measurements.csproj", "{F7A0175F-4217-4343-8A3C-EA68FAAB6B7B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Measurements", "Measurements.csproj", "{F7A0175F-4217-4343-8A3C-EA68FAAB6B7B}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Common", "..\utilities\Common\Common.csproj", "{873A59A0-2672-4494-9146-001BE03ACB96}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -15,6 +17,10 @@ Global
 		{F7A0175F-4217-4343-8A3C-EA68FAAB6B7B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F7A0175F-4217-4343-8A3C-EA68FAAB6B7B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F7A0175F-4217-4343-8A3C-EA68FAAB6B7B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{873A59A0-2672-4494-9146-001BE03ACB96}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{873A59A0-2672-4494-9146-001BE03ACB96}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{873A59A0-2672-4494-9146-001BE03ACB96}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{873A59A0-2672-4494-9146-001BE03ACB96}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Measurements/ReferenceImplementation.qs
+++ b/Measurements/ReferenceImplementation.qs
@@ -65,8 +65,8 @@ namespace Quantum.Kata.Measurements {
     
     
     // Task 1.5. |00⟩ or |11⟩ ?
-    // Input: two qubits (stored in an array or length 2) which are guaranteed to be in |00⟩ or |11⟩ state.
-    // Output: 0 if the qubits were in |00⟩ state,
+    // Input: two qubits (stored in an array of length 2) which are guaranteed to be in either the  |00⟩ or the |11⟩ state.
+    // Output: 0 if the qubits were in the |00⟩ state,
     //         1 if they were in |11⟩ state.
     // The state of the qubits at the end of the operation does not matter.
     operation ZeroZeroOrOneOne_Reference (qs : Qubit[]) : Int {
@@ -86,8 +86,8 @@ namespace Quantum.Kata.Measurements {
     operation BasisStateMeasurement_Reference (qs : Qubit[]) : Int {
         // Measurement on the first qubit gives the higher bit of the answer, on the second - the lower.
         // You can also use library function MeasureIntegerBE to get the same result.
-        mutable m1 = M(qs[0]) == Zero ? 0 | 1;
-        mutable m2 = M(qs[1]) == Zero ? 0 | 1;
+        let m1 = M(qs[0]) == Zero ? 0 | 1;
+        let m2 = M(qs[1]) == Zero ? 0 | 1;
         return m1 * 2 + m2;
     }
     
@@ -195,8 +195,8 @@ namespace Quantum.Kata.Measurements {
         H(qs[1]);
 
         // these changes brought the state back to one of the 2-qubit basis states from task 1.6 (but in different order)
-        mutable m1 = M(qs[0]) == Zero ? 0 | 1;
-        mutable m2 = M(qs[1]) == Zero ? 0 | 1;
+        let m1 = M(qs[0]) == Zero ? 0 | 1;
+        let  m2 = M(qs[1]) == Zero ? 0 | 1;
         return m2 * 2 + m1;
     }
     
@@ -250,8 +250,8 @@ namespace Quantum.Kata.Measurements {
         CNOT(qs[0], qs[1]);
         H(qs[0]);
 
-        mutable m1 = M(qs[0]) == One ? 0 | 1;
-        mutable m2 = M(qs[1]) == One ? 0 | 1;
+        let m1 = M(qs[0]) == One ? 0 | 1;
+        let m2 = M(qs[1]) == One ? 0 | 1;
         return m2 * 2 + m1;
     }
     

--- a/Measurements/ReferenceImplementation.qs
+++ b/Measurements/ReferenceImplementation.qs
@@ -22,7 +22,7 @@ namespace Quantum.Kata.Measurements {
     
     // Task 1.1. |0⟩ or |1⟩ ?
     // Input: a qubit which is guaranteed to be in |0⟩ or |1⟩ state.
-    // Output: true if qubit was in |1⟩ state, or false if it was in |0⟩ state.
+    // Output: true if the qubit was in |1⟩ state, or false if it was in |0⟩ state.
     // The state of the qubit at the end of the operation does not matter.
     operation IsQubitOne_Reference (q : Qubit) : Bool {
         return M(q) == One;
@@ -40,7 +40,7 @@ namespace Quantum.Kata.Measurements {
     // Task 1.3. |+⟩ or |-⟩ ?
     // Input: a qubit which is guaranteed to be in |+⟩ or |-⟩ state
     //        (|+⟩ = (|0⟩ + |1⟩) / sqrt(2), |-⟩ = (|0⟩ - |1⟩) / sqrt(2)).
-    // Output: true if qubit was in |+⟩ state, or false if it was in |-⟩ state.
+    // Output: true if the qubit was in |+⟩ state, or false if it was in |-⟩ state.
     // The state of the qubit at the end of the operation does not matter.
     operation IsQubitPlus_Reference (q : Qubit) : Bool {
         H(q);
@@ -54,7 +54,7 @@ namespace Quantum.Kata.Measurements {
     //      2) a qubit which is guaranteed to be in |A⟩ or |B⟩ state
     //         |A⟩ =   cos(alpha) * |0⟩ + sin(alpha) * |1⟩,
     //         |B⟩ = - sin(alpha) * |0⟩ + cos(alpha) * |1⟩.
-    // Output: true if qubit was in |A⟩ state, or false if it was in |B⟩ state.
+    // Output: true if the qubit was in |A⟩ state, or false if it was in |B⟩ state.
     // The state of the qubit at the end of the operation does not matter.
     operation IsQubitA_Reference (alpha : Double, q : Qubit) : Bool {
         // |0⟩ is converted into |A⟩ and |1⟩ into |B⟩ by Ry(2.0 * alpha)
@@ -65,14 +65,12 @@ namespace Quantum.Kata.Measurements {
     
     
     // Task 1.5. |00⟩ or |11⟩ ?
-    // Input: two qubits (stored in an array) which are guaranteed to be in |00⟩ or |11⟩ state.
-    // Output: 0 if qubits were in |00⟩ state,
+    // Input: two qubits (stored in an array or length 2) which are guaranteed to be in |00⟩ or |11⟩ state.
+    // Output: 0 if the qubits were in |00⟩ state,
     //         1 if they were in |11⟩ state.
     // The state of the qubits at the end of the operation does not matter.
     operation ZeroZeroOrOneOne_Reference (qs : Qubit[]) : Int {
         // it's enough to do one measurement on any qubit
-        let res = M(qs[0]);
-        
         return M(qs[0]) == Zero ? 0 | 1;
     }
     
@@ -86,17 +84,10 @@ namespace Quantum.Kata.Measurements {
     //         3 if they were in |11⟩ state.
     // The state of the qubits at the end of the operation does not matter.
     operation BasisStateMeasurement_Reference (qs : Qubit[]) : Int {
-        // measurement on the first qubit gives the higher bit of the answer, on the second - the lower
-        mutable m1 = 0;
-        if (M(qs[0]) == One) {
-            set m1 = 1;
-        }
-        
-        mutable m2 = 0;
-        if (M(qs[1]) == One) {
-            set m2 = 1;
-        }
-        
+        // Measurement on the first qubit gives the higher bit of the answer, on the second - the lower.
+        // You can also use library function MeasureIntegerBE to get the same result.
+        mutable m1 = M(qs[0]) == Zero ? 0 | 1;
+        mutable m2 = M(qs[1]) == Zero ? 0 | 1;
         return m1 * 2 + m2;
     }
     
@@ -116,15 +107,12 @@ namespace Quantum.Kata.Measurements {
     // Example: for bit strings [false, true, false] and [false, false, true]
     //          return 0 corresponds to state |010⟩, and return 1 corresponds to state |001⟩.
     function FindFirstDiff_Reference (bits1 : Bool[], bits2 : Bool[]) : Int {
-        
-        mutable firstDiff = -1;
         for (i in 0 .. Length(bits1) - 1) {
-            if (bits1[i] != bits2[i] and firstDiff == -1) {
-                set firstDiff = i;
+            if (bits1[i] != bits2[i]) {
+                return i;
             }
         }
-        
-        return firstDiff;
+        return -1;
     }
     
     
@@ -149,8 +137,8 @@ namespace Quantum.Kata.Measurements {
         // (and there should never be two or more Ones)
         mutable countOnes = 0;
         
-        for (i in 0 .. Length(qs) - 1) {
-            if (M(qs[i]) == One) {
+        for (q in qs) {
+            if (M(q) == One) {
                 set countOnes = countOnes + 1;
             }
         }
@@ -158,10 +146,7 @@ namespace Quantum.Kata.Measurements {
         if (countOnes > 1) {
             fail "Impossible to get multiple Ones when measuring W state";
         }
-        if (countOnes == 0) {
-            return 0;
-        }
-        return 1;
+        return countOnes == 0 ? 0 | 1;
     }
     
     
@@ -176,22 +161,19 @@ namespace Quantum.Kata.Measurements {
         // measure all qubits; if there is exactly one One, it's W state,
         // if there are no Ones or all are Ones, it's GHZ
         // (and there should never be a different number of Ones)
-        let N = Length(qs);
         mutable countOnes = 0;
         
-        for (i in 0 .. N - 1) {
-            if (M(qs[i]) == One) {
+        for (q in qs) {
+            if (M(q) == One) {
                 set countOnes = countOnes + 1;
             }
         }
         
-        if (countOnes > 1 and countOnes < Length(qs)) {
+        let N = Length(qs);
+        if (countOnes > 1 and countOnes < N) {
             fail $"Impossible to get {countOnes} Ones when measuring W state or GHZ state on {N} qubits";
         }
-        if (countOnes == 1) {
-            return 1;
-        }
-        return 0;
+        return countOnes == 1 ? 1 | 0;
     }
     
     
@@ -212,21 +194,14 @@ namespace Quantum.Kata.Measurements {
         CNOT(qs[1], qs[0]);
         H(qs[1]);
 
-        mutable m1 = 0;
-        if (M(qs[0]) == One) {
-            set m1 = 1;
-        }
-        
-        mutable m2 = 0;
-        if (M(qs[1]) == One) {
-            set m2 = 1;
-        }
-        
+        // these changes brought the state back to one of the 2-qubit basis states from task 1.6 (but in different order)
+        mutable m1 = M(qs[0]) == Zero ? 0 | 1;
+        mutable m2 = M(qs[1]) == Zero ? 0 | 1;
         return m2 * 2 + m1;
     }
     
     
-    // Task 1.11*. Distinguish four orthogonal 2-qubit states
+    // Task 1.11. Distinguish four orthogonal 2-qubit states
     // Input: two qubits (stored in an array) which are guaranteed to be in one of the four orthogonal states:
     //         |S0⟩ = (|00⟩ + |01⟩ + |10⟩ + |11⟩) / 2
     //         |S1⟩ = (|00⟩ - |01⟩ + |10⟩ - |11⟩) / 2
@@ -247,7 +222,7 @@ namespace Quantum.Kata.Measurements {
     }
     
     
-    // Task 1.12**. Distinguish four orthogonal 2-qubit states, part two
+    // Task 1.12*. Distinguish four orthogonal 2-qubit states, part two
     // Input: two qubits (stored in an array) which are guaranteed to be in one of the four orthogonal states:
     //         |S0⟩ = ( |00⟩ - |01⟩ - |10⟩ - |11⟩) / 2
     //         |S1⟩ = (-|00⟩ + |01⟩ - |10⟩ - |11⟩) / 2
@@ -275,16 +250,8 @@ namespace Quantum.Kata.Measurements {
         CNOT(qs[0], qs[1]);
         H(qs[0]);
 
-        mutable m1 = 1;
-        if (M(qs[0]) == One) {
-            set m1 = 0;
-        }
-        
-        mutable m2 = 1;
-        if (M(qs[1]) == One) {
-            set m2 = 0;
-        }
-        
+        mutable m1 = M(qs[0]) == One ? 0 | 1;
+        mutable m2 = M(qs[1]) == One ? 0 | 1;
         return m2 * 2 + m1;
     }
     

--- a/Measurements/Tasks.qs
+++ b/Measurements/Tasks.qs
@@ -16,7 +16,7 @@ namespace Quantum.Kata.Measurements {
     // "Measurements" quantum kata is a series of exercises designed
     // to get you familiar with programming in Q#.
     // It covers the following topics:
-    //  - single-qubit measurements,
+    //  - using single-qubit measurements,
     //  - discriminating orthogonal and nonorthogonal states.
     
     // Each task is wrapped in one operation preceded by the description of the task.
@@ -27,12 +27,12 @@ namespace Quantum.Kata.Measurements {
     // The tasks are given in approximate order of increasing difficulty; harder ones are marked with asterisks.
     
     //////////////////////////////////////////////////////////////////
-    // Part I. Single-Qubit Measurements
+    // Part I. Discriminating Orthogonal States
     //////////////////////////////////////////////////////////////////
     
     // Task 1.1. |0⟩ or |1⟩ ?
     // Input: a qubit which is guaranteed to be in |0⟩ or |1⟩ state.
-    // Output: true if qubit was in |1⟩ state, or false if it was in |0⟩ state.
+    // Output: true if the qubit was in the |1⟩ state, or false if it was in the |0⟩ state.
     // The state of the qubit at the end of the operation does not matter.
     operation IsQubitOne (q : Qubit) : Bool {
         // The operation M will measure a qubit in the Z basis (|0⟩ and |1⟩ basis)
@@ -40,7 +40,7 @@ namespace Quantum.Kata.Measurements {
         // To answer the question, you need to perform the measurement and check whether the result
         // equals One - either directly or using library function IsResultOne.
         //
-        // Replace the returned expression with (M(q) == One)
+        // Replace the returned expression with (M(q) == One).
         // Then rebuild the project and rerun the tests - T101_IsQubitOne_Test should now pass!
 
         return false;
@@ -58,7 +58,7 @@ namespace Quantum.Kata.Measurements {
     // Task 1.3. |+⟩ or |-⟩ ?
     // Input: a qubit which is guaranteed to be in |+⟩ or |-⟩ state
     //        (|+⟩ = (|0⟩ + |1⟩) / sqrt(2), |-⟩ = (|0⟩ - |1⟩) / sqrt(2)).
-    // Output: true if qubit was in |+⟩ state, or false if it was in |-⟩ state.
+    // Output: true if the qubit was in |+⟩ state, or false if it was in |-⟩ state.
     // The state of the qubit at the end of the operation does not matter.
     operation IsQubitPlus (q : Qubit) : Bool {
         // ...
@@ -68,21 +68,21 @@ namespace Quantum.Kata.Measurements {
     
     // Task 1.4. |A⟩ or |B⟩ ?
     // Inputs:
-    //      1) angle alpha, in radians, represented as Double
+    //      1) angle α, in radians, represented as a Double
     //      2) a qubit which is guaranteed to be in |A⟩ or |B⟩ state
-    //         |A⟩ =   cos(alpha) * |0⟩ + sin(alpha) * |1⟩,
-    //         |B⟩ = - sin(alpha) * |0⟩ + cos(alpha) * |1⟩.
-    // Output: true if qubit was in |A⟩ state, or false if it was in |B⟩ state.
+    //         |A⟩ =   cos α |0⟩ + sin α |1⟩,
+    //         |B⟩ = - sin α |0⟩ + cos α |1⟩.
+    // Output: true if the qubit was in |A⟩ state, or false if it was in |B⟩ state.
     // The state of the qubit at the end of the operation does not matter.
-    operation IsQubitA (alpha : Double, q : Qubit) : Bool {
+    operation IsQubitA (α : Double, q : Qubit) : Bool {
         // ...
         return false;
     }
     
     
     // Task 1.5. |00⟩ or |11⟩ ?
-    // Input: two qubits (stored in an array) which are guaranteed to be in |00⟩ or |11⟩ state.
-    // Output: 0 if qubits were in |00⟩ state,
+    // Input: two qubits (stored in an array or length 2) which are guaranteed to be in |00⟩ or |11⟩ state.
+    // Output: 0 if the qubits were in |00⟩ state,
     //         1 if they were in |11⟩ state.
     // The state of the qubits at the end of the operation does not matter.
     operation ZeroZeroOrOneOne (qs : Qubit[]) : Int {
@@ -94,7 +94,7 @@ namespace Quantum.Kata.Measurements {
     // Task 1.6. Distinguish four basis states
     // Input: two qubits (stored in an array) which are guaranteed to be
     //        in one of the four basis states (|00⟩, |01⟩, |10⟩ or |11⟩).
-    // Output: 0 if qubits were in |00⟩ state,
+    // Output: 0 if the qubits were in |00⟩ state,
     //         1 if they were in |01⟩ state,
     //         2 if they were in |10⟩ state,
     //         3 if they were in |11⟩ state.
@@ -113,12 +113,12 @@ namespace Quantum.Kata.Measurements {
     //      1) N qubits (stored in an array) which are guaranteed to be
     //         in one of the two basis states described by the given bit strings.
     //      2) two bit string represented as Bool[]s.
-    // Output: 0 if qubits were in the basis state described by the first bit string,
+    // Output: 0 if the qubits were in the basis state described by the first bit string,
     //         1 if they were in the basis state described by the second bit string.
     // Bit values false and true correspond to |0⟩ and |1⟩ states.
     // The state of the qubits at the end of the operation does not matter.
-    // You are guaranteed that the both bit strings have the same length as the qubit array,
-    // and that the bit strings will differ in at least one bit.
+    // You are guaranteed that both bit strings have the same length as the qubit array,
+    // and that the bit strings differ in at least one bit.
     // You can use exactly one measurement.
     // Example: for bit strings [false, true, false] and [false, false, true]
     //          return 0 corresponds to state |010⟩, and return 1 corresponds to state |001⟩.
@@ -132,7 +132,7 @@ namespace Quantum.Kata.Measurements {
     // Input: N qubits (stored in an array) which are guaranteed to be
     //        either in |0...0⟩ state
     //        or in W state (https://en.wikipedia.org/wiki/W_state).
-    // Output: 0 if qubits were in |0...0⟩ state,
+    // Output: 0 if the qubits were in |0...0⟩ state,
     //         1 if they were in W state.
     // The state of the qubits at the end of the operation does not matter.
     operation AllZerosOrWState (qs : Qubit[]) : Int {
@@ -143,10 +143,10 @@ namespace Quantum.Kata.Measurements {
     
     // Task 1.9. GHZ state or W state ?
     // Input: N >= 2 qubits (stored in an array) which are guaranteed to be
-    //        either in GHZ state (https://en.wikipedia.org/wiki/Greenberger%E2%80%93Horne%E2%80%93Zeilinger_state)
-    //        or in W state (https://en.wikipedia.org/wiki/W_state).
-    // Output: 0 if qubits were in GHZ state,
-    //         1 if they were in W state.
+    //        either in the GHZ state (https://en.wikipedia.org/wiki/Greenberger%E2%80%93Horne%E2%80%93Zeilinger_state)
+    //        or in the W state (https://en.wikipedia.org/wiki/W_state).
+    // Output: 0 if the qubits were in the GHZ state,
+    //         1 if they were in the W state.
     // The state of the qubits at the end of the operation does not matter.
     operation GHZOrWState (qs : Qubit[]) : Int {
         // ...
@@ -160,7 +160,7 @@ namespace Quantum.Kata.Measurements {
     //         |Φ⁻⟩ = (|00⟩ - |11⟩) / sqrt(2)
     //         |Ψ⁺⟩ = (|01⟩ + |10⟩) / sqrt(2)
     //         |Ψ⁻⟩ = (|01⟩ - |10⟩) / sqrt(2)
-    // Output: 0 if qubits were in |Φ⁺⟩ state,
+    // Output: 0 if the qubits were in |Φ⁺⟩ state,
     //         1 if they were in |Φ⁻⟩ state,
     //         2 if they were in |Ψ⁺⟩ state,
     //         3 if they were in |Ψ⁻⟩ state.
@@ -173,7 +173,7 @@ namespace Quantum.Kata.Measurements {
     }
     
     
-    // Task 1.11*. Distinguish four orthogonal 2-qubit states
+    // Task 1.11. Distinguish four orthogonal 2-qubit states
     // Input: two qubits (stored in an array) which are guaranteed to be in one of the four orthogonal states:
     //         |S0⟩ = (|00⟩ + |01⟩ + |10⟩ + |11⟩) / 2
     //         |S1⟩ = (|00⟩ - |01⟩ + |10⟩ - |11⟩) / 2
@@ -190,7 +190,7 @@ namespace Quantum.Kata.Measurements {
     }
     
     
-    // Task 1.12**. Distinguish four orthogonal 2-qubit states, part two
+    // Task 1.12*. Distinguish four orthogonal 2-qubit states, part two
     // Input: two qubits (stored in an array) which are guaranteed to be in one of the four orthogonal states:
     //         |S0⟩ = ( |00⟩ - |01⟩ - |10⟩ - |11⟩) / 2
     //         |S1⟩ = (-|00⟩ + |01⟩ - |10⟩ - |11⟩) / 2
@@ -209,10 +209,11 @@ namespace Quantum.Kata.Measurements {
     
     // Task 1.13**. Distinguish two orthogonal states on three qubits
     // Input: Three qubits (stored in an array) which are guaranteed to be in either one of the
-    //        following two states: (where ω = exp(2π i/3) denotes a primitive 3rd root of unity):
+    //        following two states:
     //        1/sqrt(3) ( |100⟩ + ω |010⟩ + ω² |001⟩ ),
     //        1/sqrt(3) ( |100⟩ + ω² |010⟩ + ω |001⟩ ).
-    // Output: 0 if qubits were in the first superposition,
+    //        Here ω = exp(2π i/3) denotes a primitive 3rd root of unity.
+    // Output: 0 if the qubits were in the first superposition,
     //         1 if they were in the second superposition.
     // The state of the qubits at the end of the operation does not matter.
     operation ThreeQubitMeasurement (qs : Qubit[]) : Int {
@@ -250,10 +251,10 @@ namespace Quantum.Kata.Measurements {
     //         1 if it was in |+⟩ state,
     //         -1 if you can't decide, i.e., an "inconclusive" result.
     // Your solution:
-    //  - can never give 0 or 1 answer incorrectly (i.e., identify |0⟩ as 1 or |+⟩ as 0).
-    //  - must give inconclusive (-1) answer at most 80% of the times.
-    //  - must correctly identify |0⟩ state as 0 at least 10% of the times.
-    //  - must correctly identify |+⟩ state as 1 at least 10% of the times.
+    //  - should never give 0 or 1 answer incorrectly (i.e., identify |0⟩ as 1 or |+⟩ as 0).
+    //  - is allowed to give inconclusive (-1) answer in at most 80% of the cases.
+    //  - must correctly identify |0⟩ state as 0 in at least 10% of the cases.
+    //  - must correctly identify |+⟩ state as 1 in at least 10% of the cases.
     //
     // The state of the qubit at the end of the operation does not matter.
     // You are allowed to use ancilla qubit(s).
@@ -270,9 +271,9 @@ namespace Quantum.Kata.Measurements {
     //        |B⟩ = 1/sqrt(2) (|0⟩ + ω |1⟩),
     //        |C⟩ = 1/sqrt(2) (|0⟩ + ω² |1⟩),
     //	      where ω = exp(2iπ/3) denotes a primitive, complex 3rd root of unity.
-    // Output: 1 or 2 if qubit was in the |A⟩ state,
-    //         0 or 2 if qubit was in the |B⟩ state,
-    //         0 or 1 if qubit was in the |C⟩ state.
+    // Output: 1 or 2 if the qubit was in the |A⟩ state,
+    //         0 or 2 if the qubit was in the |B⟩ state,
+    //         0 or 1 if the qubit was in the |C⟩ state.
     // The state of the qubit at the end of the operation does not matter.
     // Note: in this task you have to succeed with probability 1, i.e., you are never allowed
     //       to give an incorrect answer.

--- a/Measurements/Tasks.qs
+++ b/Measurements/Tasks.qs
@@ -81,8 +81,8 @@ namespace Quantum.Kata.Measurements {
     
     
     // Task 1.5. |00⟩ or |11⟩ ?
-    // Input: two qubits (stored in an array or length 2) which are guaranteed to be in |00⟩ or |11⟩ state.
-    // Output: 0 if the qubits were in |00⟩ state,
+    // Input: two qubits (stored in an array of length 2) which are guaranteed to be in either the |00⟩ or the |11⟩ state.
+    // Output: 0 if the qubits were in the |00⟩ state,
     //         1 if they were in |11⟩ state.
     // The state of the qubits at the end of the operation does not matter.
     operation ZeroZeroOrOneOne (qs : Qubit[]) : Int {
@@ -252,7 +252,7 @@ namespace Quantum.Kata.Measurements {
     //         -1 if you can't decide, i.e., an "inconclusive" result.
     // Your solution:
     //  - should never give 0 or 1 answer incorrectly (i.e., identify |0⟩ as 1 or |+⟩ as 0).
-    //  - is allowed to give inconclusive (-1) answer in at most 80% of the cases.
+    //  - may give an inconclusive (-1) answer in at most 80% of the cases.
     //  - must correctly identify |0⟩ state as 0 in at least 10% of the cases.
     //  - must correctly identify |+⟩ state as 1 in at least 10% of the cases.
     //

--- a/Measurements/Tasks.qs
+++ b/Measurements/Tasks.qs
@@ -13,7 +13,7 @@ namespace Quantum.Kata.Measurements {
     // Welcome!
     //////////////////////////////////////////////////////////////////
     
-    // "Measurements" quantum kata is a series of exercises designed
+    // The "Measurements" quantum kata is a series of exercises designed
     // to get you familiar with programming in Q#.
     // It covers the following topics:
     //  - using single-qubit measurements,
@@ -31,7 +31,7 @@ namespace Quantum.Kata.Measurements {
     //////////////////////////////////////////////////////////////////
     
     // Task 1.1. |0⟩ or |1⟩ ?
-    // Input: a qubit which is guaranteed to be in |0⟩ or |1⟩ state.
+    // Input: a qubit which is guaranteed to be in either the |0⟩ or the |1⟩ state.
     // Output: true if the qubit was in the |1⟩ state, or false if it was in the |0⟩ state.
     // The state of the qubit at the end of the operation does not matter.
     operation IsQubitOne (q : Qubit) : Bool {
@@ -56,9 +56,9 @@ namespace Quantum.Kata.Measurements {
     
     
     // Task 1.3. |+⟩ or |-⟩ ?
-    // Input: a qubit which is guaranteed to be in |+⟩ or |-⟩ state
+    // Input: a qubit which is guaranteed to be in either the |+⟩ or the |-⟩ state
     //        (|+⟩ = (|0⟩ + |1⟩) / sqrt(2), |-⟩ = (|0⟩ - |1⟩) / sqrt(2)).
-    // Output: true if the qubit was in |+⟩ state, or false if it was in |-⟩ state.
+    // Output: true if the qubit was in the |+⟩ state, or false if it was in the |-⟩ state.
     // The state of the qubit at the end of the operation does not matter.
     operation IsQubitPlus (q : Qubit) : Bool {
         // ...
@@ -69,12 +69,12 @@ namespace Quantum.Kata.Measurements {
     // Task 1.4. |A⟩ or |B⟩ ?
     // Inputs:
     //      1) angle α, in radians, represented as a Double
-    //      2) a qubit which is guaranteed to be in |A⟩ or |B⟩ state
+    //      2) a qubit which is guaranteed to be in either the |A⟩ or the |B⟩ state, where
     //         |A⟩ =   cos α |0⟩ + sin α |1⟩,
     //         |B⟩ = - sin α |0⟩ + cos α |1⟩.
-    // Output: true if the qubit was in |A⟩ state, or false if it was in |B⟩ state.
+    // Output: true if the qubit was in the |A⟩ state, or false if it was in the |B⟩ state.
     // The state of the qubit at the end of the operation does not matter.
-    operation IsQubitA (α : Double, q : Qubit) : Bool {
+    operation IsQubitA (alpha : Double, q : Qubit) : Bool {
         // ...
         return false;
     }
@@ -130,10 +130,10 @@ namespace Quantum.Kata.Measurements {
     
     // Task 1.8. |0...0⟩ state or W state ?
     // Input: N qubits (stored in an array) which are guaranteed to be
-    //        either in |0...0⟩ state
-    //        or in W state (https://en.wikipedia.org/wiki/W_state).
-    // Output: 0 if the qubits were in |0...0⟩ state,
-    //         1 if they were in W state.
+    //        either in the |0...0⟩ state
+    //        or in the W state (https://en.wikipedia.org/wiki/W_state).
+    // Output: 0 if the qubits were in the |0...0⟩ state,
+    //         1 if they were in the W state.
     // The state of the qubits at the end of the operation does not matter.
     operation AllZerosOrWState (qs : Qubit[]) : Int {
         // ...
@@ -234,8 +234,8 @@ namespace Quantum.Kata.Measurements {
     
     // Task 2.1*. |0⟩ or |+⟩ ?
     //           (quantum hypothesis testing or state discrimination with minimum error)
-    // Input: a qubit which is guaranteed to be in |0⟩ or |+⟩ state with equal probability.
-    // Output: true if qubit was in |0⟩ state, or false if it was in |+⟩ state.
+    // Input: a qubit which is guaranteed to be in either the |0⟩ or the |+⟩ state with equal probability.
+    // Output: true if qubit was in the |0⟩ state, or false if it was in the |+⟩ state.
     // The state of the qubit at the end of the operation does not matter.
     // Note: in this task you have to get accuracy of at least 80%.
     operation IsQubitPlusOrZero (q : Qubit) : Bool {
@@ -246,9 +246,9 @@ namespace Quantum.Kata.Measurements {
     
     // Task 2.2**. |0⟩, |+⟩ or inconclusive?
     //             (unambiguous state discrimination)
-    // Input: a qubit which is guaranteed to be in |0⟩ or |+⟩ state with equal probability.
-    // Output: 0 if qubit was in |0⟩ state,
-    //         1 if it was in |+⟩ state,
+    // Input: a qubit which is guaranteed to be in either the |0⟩ or the |+⟩ state with equal probability.
+    // Output: 0 if qubit was in the |0⟩ state,
+    //         1 if it was in the |+⟩ state,
     //         -1 if you can't decide, i.e., an "inconclusive" result.
     // Your solution:
     //  - should never give 0 or 1 answer incorrectly (i.e., identify |0⟩ as 1 or |+⟩ as 0).

--- a/Measurements/TestSuiteRunner.cs
+++ b/Measurements/TestSuiteRunner.cs
@@ -8,9 +8,10 @@
 //////////////////////////////////////////////////////////////////////
 
 using Microsoft.Quantum.Simulation.XUnit;
-using Microsoft.Quantum.Simulation.Simulators;
 using Xunit.Abstractions;
 using System.Diagnostics;
+
+using Microsoft.Quantum.Katas;
 
 namespace Quantum.Kata.Measurements
 {
@@ -30,7 +31,7 @@ namespace Quantum.Kata.Measurements
         [OperationDriver(TestNamespace = "Quantum.Kata.Measurements")]
         public void TestTarget(TestOperation op)
         {
-            using (var sim = new QuantumSimulator())
+            using (var sim = new CounterSimulator())
             {
                 // OnLog defines action(s) performed when Q# test calls function Message
                 sim.OnLog += (msg) => { output.WriteLine(msg); };


### PR DESCRIPTION
This change includes the fix for https://github.com/Microsoft/QuantumKatas/issues/68 (count the measurements used to solve the task).

The new notebook should be possible to preview at https://mybinder.org/v2/gh/Microsoft/QuantumKatas/mariia/measurements-notebook?filepath=Measurements%2FMeasurements.ipynb, right now it is still building the image.