### PR TITLE
Fix typo in BasicGates.ipynb

### DIFF
--- a/BasicGates/BasicGates.ipynb
+++ b/BasicGates/BasicGates.ipynb
@@ -235,7 +235,7 @@
     "\n",
     "**Goal:**  Change the state of the qubit as follows:\n",
     "- If the qubit is in state $|0\\rangle$, don't change its state.\n",
-    "- If the qubit is in state $|1\\rangle$, change its state to $\\exp^{i\\alpha} |0\\rangle$.\n",
+    "- If the qubit is in state $|1\\rangle$, change its state to $\\exp^{i\\alpha} |1\\rangle$.\n",
     "- If the qubit is in superposition, change its state according to the effect on basis vectors.\n"
    ]
   },


### PR DESCRIPTION
Task 1.6:
|1> should change to exp^i*alpha |1> instead of exp^i*alpha |0>