### PR TITLE
Adding kata magic to allow us validating notebooks.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ Tests/build
 # test outputs
 TestResults/
 *.qxe
+Check.ipynb
 
 # Random VS files
 *.suo

--- a/BasicGates/ReferenceImplementation.qs
+++ b/BasicGates/ReferenceImplementation.qs
@@ -10,7 +10,7 @@
 
 namespace Quantum.Kata.BasicGates {
     
-    open Microsoft.Quantum.Primitive;
+    open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Canon;
     
     

--- a/scripts/validate-notebooks.ps1
+++ b/scripts/validate-notebooks.ps1
@@ -1,0 +1,26 @@
+$ErrorActionPreference = 'Stop'
+
+function validate {
+    Param($folder)
+
+    pushd $folder
+    $CheckNotebook = 'Check.ipynb'
+
+    if (Test-Path $CheckNotebook) 
+    {
+        Remove-Item $CheckNotebook
+    }
+
+    $Notebook = (Get-ChildItem *.ipynb)
+    Write-Host "Checking notebook $Notebook."
+
+    (Get-Content $Notebook -Raw) |  ForEach-Object { $_.replace('%kata', '%check_kata') } | Set-Content $CheckNotebook -NoNewline
+    jupyter nbconvert $CheckNotebook --execute  --ExecutePreprocessor.timeout=120
+
+    popd
+}
+
+validate ..\BasicGates
+validate ..\Measurements
+validate ..\Superposition
+validate ..\DeutschJozsaAlgorithm

--- a/scripts/validate-notebooks.ps1
+++ b/scripts/validate-notebooks.ps1
@@ -1,26 +1,51 @@
-$ErrorActionPreference = 'Stop'
+# Script to validate Jupyter notebooks.
 
+#
+# This function takes a folder with Katas. Copies the corresponding 
+# jupyter notebook into a "Check.ipynb" that replaces the %kata magic
+# with a %check_kata magic that runs the kata not with the user-supplied code
+# but with the Reference implementation.
+# If the execution fails or has warnings, the execution of the notebook
+# will fail.
 function validate {
     Param($folder)
-
     pushd $folder
+
+    # Name of the notebook that will be used for checking katas.
     $CheckNotebook = 'Check.ipynb'
 
-    if (Test-Path $CheckNotebook) 
-    {
+    # Make sure old versions are removed.
+    if (Test-Path $CheckNotebook)  {
         Remove-Item $CheckNotebook
     }
 
+    # Find the name of the kata's notebook.
     $Notebook = (Get-ChildItem *.ipynb)
     Write-Host "Checking notebook $Notebook."
 
+    #  convert %kata to %check_kata. run Jupyter nbconvert to execute the kata.
     (Get-Content $Notebook -Raw) |  ForEach-Object { $_.replace('%kata', '%check_kata') } | Set-Content $CheckNotebook -NoNewline
     jupyter nbconvert $CheckNotebook --execute  --ExecutePreprocessor.timeout=120
 
+    # if jupyter returns an error code, return that this notebook is invalid:
+    $invalid = ($LastExitCode -ne 0)
+    Write-Host "Result: " $LastExitCode
+
     popd
+    return $invalid
 }
 
-validate ..\BasicGates
-validate ..\Measurements
-validate ..\Superposition
-validate ..\DeutschJozsaAlgorithm
+# List of Katas to verify:
+$errors = $false
+$errors = (validate ..\Measurements) -or $errors
+$errors = (validate ..\BasicGates) -or $errors
+$errors = (validate ..\Superposition) -or $errors
+$errors = (validate ..\DeutschJozsaAlgorithm) -or $errors
+
+$result = 0
+if ($errors) { 
+    Write-Host "##vso[task.logissue type=error;]Validation errors for Jupyter notebooks."
+    $result = 1 
+}
+
+exit($result)

--- a/utilities/Microsoft.Quantum.Katas/CheckKataMagic.cs
+++ b/utilities/Microsoft.Quantum.Katas/CheckKataMagic.cs
@@ -1,0 +1,203 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using System;
+using System.Linq;
+using Microsoft.Extensions.Logging;
+using Microsoft.Jupyter.Core;
+using Microsoft.Quantum.IQSharp;
+using Microsoft.Quantum.IQSharp.Common;
+using Microsoft.Quantum.Simulation.Common;
+using Microsoft.Quantum.Simulation.Core;
+
+namespace Microsoft.Quantum.Katas
+{
+    public class CheckKataMagic : MagicSymbol
+    {
+        /// <summary>
+        /// IQ# Magic that checks that the Reference implementation of a Kata runs successfully.
+        /// </summary>
+        public CheckKataMagic(IOperationResolver resolver, ICompilerService compiler, ILogger<KataMagic> logger)
+        {
+            this.Name = $"%check_kata";
+            this.Documentation = new Documentation() { Summary = "Checks the resference implementaiton of a single kata." };
+            this.Kind = SymbolKind.Magic;
+            this.Execute = this.Run;
+
+            this.Resolver = resolver;
+            this.Compiler = compiler;
+            this.Logger = logger;
+        }
+
+        /// <summary>
+        /// The Resolver let's us find compiled Q# operations from the workspace
+        /// </summary>
+        protected IOperationResolver Resolver { get; }
+
+        /// <summary>
+        /// The list of user-defined Q# code snippets from the notebook.
+        /// </summary>
+        protected ICompilerService Compiler { get; }
+
+        protected ILogger<KataMagic> Logger { get; }
+
+        /// <summary>
+        /// What this Magic does when triggered. It will:
+        /// - find the Kata to execute based on the Kata name,
+        /// - compile the code after found after the name as the user's answer.
+        /// - run (simulate) the kata.
+        /// </summary>
+        public virtual ExecutionResult Run(string input, IChannel channel)
+        {
+            channel = channel.WithNewLines();
+
+            // Expect exactly two arguments, the name of the Kata and the user's answer (code).
+            var args = input?.Split(new char[] { ' ', '\n', '\t' }, 2);
+            if (args == null || args.Length != 2)
+            {
+                channel.Stderr("Invalid parameters. Usage: `%kata Test \"Q# operation\"`");
+                return ExecuteStatus.Error.ToExecutionResult();
+            }
+
+            var name = args[0];
+            var code = args[1];
+
+            var kata = FindKata(name);
+            if (kata == null)
+            {
+                channel.Stderr($"Invalid test name: {name}");
+                return ExecuteStatus.Error.ToExecutionResult();
+            }
+
+            var userAnswer = Compile(code, channel);
+            if (userAnswer == null) { return ExecuteStatus.Error.ToExecutionResult(); }
+
+            return Simulate(kata, userAnswer, channel)
+                ? "Success!".ToExecutionResult()
+                : ExecuteStatus.Error.ToExecutionResult();
+        }
+
+        /// <summary>
+        /// Compiles the given code. Checks there is only one operation defined in the code,
+        /// and returns its corresponding OperationInfo
+        /// </summary>
+        public virtual string Compile(string code, IChannel channel)
+        {
+            try
+            {
+                var result = Compiler.IdentifyElements(code);
+
+                // Gets the names of all the operations found for this snippet
+                var opsNames =
+                    result
+                        .Where(e => e.IsQsCallable)
+                        .Select(e => e.ToFullName().WithoutNamespace(Microsoft.Quantum.IQSharp.Snippets.SNIPPETS_NAMESPACE))
+                        .OrderBy(o => o)
+                        .ToArray();
+
+                if (opsNames.Length > 1)
+                {
+                    channel.Stdout("Expecting only one Q# operation in code. Using the first one");
+                }
+
+                return opsNames.First();
+            }
+            catch (CompilationErrorsException c)
+            {
+                foreach (var m in c.Errors) channel.Stderr(m);
+                return null;
+            }
+            catch (Exception e)
+            {
+                Logger?.LogWarning(e, "Unexpected error.");
+                channel.Stderr(e.Message);
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Executes the given kata using the provided <c>userAnswer</c> as the actual answer.
+        /// To do this, it finds another operation with the same name but in the Kata's namespace
+        /// (by calling `FindRawAnswer`) and replace its implementation with the userAnswer
+        /// in the simulator.
+        /// </summary>
+        public virtual bool Simulate(OperationInfo kata, string userAnswer, IChannel channel)
+        {
+            var rawAnswer = FindRawAnswer(kata, userAnswer);
+            if (rawAnswer == null)
+            {
+                channel.Stderr($"Invalid task: {userAnswer}");
+                return false;
+            }
+
+            var referenceAnser = FindReferenceImplementation(kata, userAnswer);
+            if (referenceAnser == null)
+            {
+                channel.Stderr($"Invalid Reference answer: {userAnswer}");
+                return false;
+            }
+
+            try
+            {
+                var qsim = CreateSimulator();
+                var hasWarnings = false;
+
+                qsim.DisableLogToConsole();
+                qsim.Register(rawAnswer.RoslynType, referenceAnser.RoslynType, typeof(ICallable));
+                qsim.OnLog += (msg) =>
+                {
+                    hasWarnings = msg?.StartsWith("[WARNING]") ?? hasWarnings;
+                    channel.Stdout(msg);
+                };
+
+                var value = kata.RunAsync(qsim, null).Result;
+
+                if (qsim is IDisposable dis) { dis.Dispose(); }
+
+                return !hasWarnings;
+            }
+            catch (AggregateException agg)
+            {
+                foreach (var e in agg.InnerExceptions) { channel.Stderr(e.Message); }
+                channel.Stderr($"Try again!");
+                return false;
+            }
+            catch (Exception e)
+            {
+                channel.Stderr(e.Message);
+                channel.Stderr($"Try again!");
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Creates the instance of the simulator to use to run the Kata 
+        /// (for now always CounterSimulator from the same package).
+        /// </summary>
+        public virtual SimulatorBase CreateSimulator() =>
+            new CounterSimulator();
+
+        /// <summary>
+        /// Returns the OperationInfo for the Kata to run.
+        /// </summary>
+        public virtual OperationInfo FindKata(string kataName) =>
+             Resolver.Resolve(kataName);
+
+        /// <summary>
+        /// Returns the original shell for the Kata's answer in the workspace for the given userAnswer.
+        /// It does this by finding another operation with the same name as the `userAnswer` but in the 
+        /// Kata's namespace
+        /// </summary>
+        public virtual OperationInfo FindRawAnswer(OperationInfo kata, string userAnswer) =>
+            Resolver.Resolve($"{kata.Header.QualifiedName.Namespace.Value}.{userAnswer}");
+
+        /// <summary>
+        /// Returns the original shell for the Kata's answer in the workspace for the given userAnswer.
+        /// It does this by finding another operation with the same name as the `userAnswer` but in the 
+        /// Kata's namespace
+        /// </summary>
+        public virtual OperationInfo FindReferenceImplementation(OperationInfo kata, string userAnswer) =>
+            Resolver.Resolve($"{kata.Header.QualifiedName.Namespace.Value}.{userAnswer}_Reference");
+    }
+}
+


### PR DESCRIPTION
Adds the `%check_kata` jupyter magic that executes the notebooks using the Reference implementation of a Tasks instead of the user-provided code.
Adds also a script to create a `Check` notebook, which is the same as the original notebook, except with all `%kata` replaced with `%check_kata`, and execute them.