### PR TITLE
Escape double-quotes in SolveSATWithGrover notebook

### DIFF
--- a/SolveSATWithGrover/SolveSATWithGrover.ipynb
+++ b/SolveSATWithGrover/SolveSATWithGrover.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Solving SAT problem with Grover's algorithm\n",
     "\n",
-    "The **"Solving SAT problem with Grover's algorithm"** quantum kata is a series of exercises designed\n",
+    "The **\"Solving SAT problem with Grover's algorithm\"** quantum kata is a series of exercises designed\n",
     "to get you comfortable with using Grover's algorithm to solve realistic problems\n",
     "using boolean satisfiability problems (SAT) as an example.\n",
     "\n",


### PR DESCRIPTION
Without the escaping these quotation marks break the json format of the notebook, so it doesn't load at all. Thanks to @jackhyder for catching this!