### PR TITLE
Fix path to tutorial notebook in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -94,5 +94,5 @@ RUN dotnet build Teleportation
 RUN jupyter nbconvert Teleportation/Teleportation.ipynb --execute --stdout --to markdown  --allow-errors  --ExecutePreprocessor.timeout=120
 
 RUN dotnet build tutorials/DeutschJozsaAlgorithm
-RUN jupyter nbconvert DeutschJozsaAlgorithm/DeutschJozsaAlgorithmTutorial.ipynb --execute --stdout --to markdown  --allow-errors  --ExecutePreprocessor.timeout=120
+RUN jupyter nbconvert tutorials/DeutschJozsaAlgorithm/DeutschJozsaAlgorithmTutorial.ipynb --execute --stdout --to markdown  --allow-errors  --ExecutePreprocessor.timeout=120
 


### PR DESCRIPTION
The path listed now does not exist, so Binder can't build the image to use.