### PR TITLE
Use R1 rather than Rz

### DIFF
--- a/BasicGates/ReferenceImplementation.qs
+++ b/BasicGates/ReferenceImplementation.qs
@@ -78,7 +78,7 @@ namespace Quantum.Kata.BasicGates {
     //        If the qubit is in state |1⟩, change its state to exp(i*alpha)|1⟩.
     //        If the qubit is in superposition, change its state according to the effect on basis vectors.
     operation PhaseChange_Reference (alpha : Double, q : Qubit) : Unit is Adj {
-        Rz(alpha, q);
+        R1(alpha, q);
     }
 
 


### PR DESCRIPTION
R1 actually matches the requirements.

I know that the computer can't distinguish between the two and they are only differ by a global phase, but I think using Rz is confusing to people who are trying to learn.