### PR TITLE
BasicGates kata: Improve test harness

### DIFF
--- a/BasicGates/BasicGates.ipynb
+++ b/BasicGates/BasicGates.ipynb
@@ -73,7 +73,12 @@
     "\n",
     "### Q# materials\n",
     "\n",
-    "* Basic gates provided in Q# belong to the `Microsoft.Quantum.Intrinsic` namespace and are listed [here](https://docs.microsoft.com/qsharp/api/qsharp/microsoft.quantum.intrinsic)."
+    "* Basic gates provided in Q# belong to the `Microsoft.Quantum.Intrinsic` namespace and are listed [here](https://docs.microsoft.com/qsharp/api/qsharp/microsoft.quantum.intrinsic).\n",
+    "\n",
+    "> Note that all operations in this section have `is Adj+Ctl` in their signature.\n",
+    "This means that they should be implemented in a way that allows Q# \n",
+    "to compute their adjoint and controlled variants automatically.\n",
+    "Since each task is solved using only intrinsic gates, you should not need to put any special effort in this."
    ]
   },
   {
@@ -93,10 +98,7 @@
     "If the qubit is in state $|1\\rangle$, change its state to $|0\\rangle$.\n",
     "\n",
     "> Note that this operation is self-adjoint: applying it for a second time\n",
-    "> returns the qubit to the original state. \n",
-    "\n",
-    "> `is Adj+Ctl` at the end of the operation signature means that Q# will compute \n",
-    "> the operation that returns the qubit to the original state and the controlled version of the operation automatically."
+    "> returns the qubit to the original state. "
    ]
   },
   {

--- a/BasicGates/BasicGates.ipynb
+++ b/BasicGates/BasicGates.ipynb
@@ -93,8 +93,10 @@
     "If the qubit is in state $|1\\rangle$, change its state to $|0\\rangle$.\n",
     "\n",
     "> Note that this operation is self-adjoint: applying it for a second time\n",
-    "> returns the qubit to the original state. `is Adj` at the end of the operation signature means that Q# will compute \n",
-    "> the operation that returns the qubit to the original state automatically."
+    "> returns the qubit to the original state. \n",
+    "\n",
+    "> `is Adj+Ctl` at the end of the operation signature means that Q# will compute \n",
+    "> the operation that returns the qubit to the original state and the controlled version of the operation automatically."
    ]
   },
   {
@@ -105,7 +107,7 @@
    "source": [
     "%kata T11_StateFlip_Test \n",
     "\n",
-    "operation StateFlip (q : Qubit) : Unit is Adj {\n",
+    "operation StateFlip (q : Qubit) : Unit is Adj+Ctl {\n",
     "    // The Pauli X gate will change the |0⟩ state to the |1⟩ state and vice versa.\n",
     "    // Type X(q);\n",
     "    // Then run the cell using Ctrl/⌘+Enter.\n",
@@ -140,7 +142,7 @@
    "source": [
     "%kata T12_BasisChange_Test \n",
     "\n",
-    "operation BasisChange (q : Qubit) : Unit is Adj {\n",
+    "operation BasisChange (q : Qubit) : Unit is Adj+Ctl {\n",
     "    // ...\n",
     "}"
    ]
@@ -164,7 +166,7 @@
    "source": [
     "%kata T13_SignFlip_Test \n",
     "\n",
-    "operation SignFlip (q : Qubit) : Unit is Adj {\n",
+    "operation SignFlip (q : Qubit) : Unit is Adj+Ctl {\n",
     "    // ...\n",
     "}"
    ]
@@ -197,7 +199,7 @@
    "source": [
     "%kata T14_AmplitudeChange_Test\n",
     "\n",
-    "operation AmplitudeChange (alpha : Double, q : Qubit) : Unit is Adj {\n",
+    "operation AmplitudeChange (alpha : Double, q : Qubit) : Unit is Adj+Ctl {\n",
     "    // ...\n",
     "}"
    ]
@@ -210,7 +212,7 @@
     "\n",
     "**Input:** A qubit in state $|\\psi\\rangle = \\alpha |0\\rangle + \\beta |1\\rangle$.\n",
     "\n",
-    "**Goal:** Change the qubit state to $\\alpha |0\\rangle + i\\beta |1\\rangle$ (add a relative phase $i$ to $|1\\rangle$ component of the superposition).\n"
+    "**Goal:** Change the qubit state to $\\alpha |0\\rangle + \\color{red}i\\beta |1\\rangle$ (add a relative phase $i$ to $|1\\rangle$ component of the superposition).\n"
    ]
   },
   {
@@ -221,7 +223,7 @@
    "source": [
     "%kata T15_PhaseFlip_Test\n",
     "\n",
-    "operation PhaseFlip (q : Qubit) : Unit is Adj {    \n",
+    "operation PhaseFlip (q : Qubit) : Unit is Adj+Ctl {\n",
     "    // ...\n",
     "}"
    ]
@@ -239,8 +241,8 @@
     "\n",
     "**Goal:**  Change the state of the qubit as follows:\n",
     "- If the qubit is in state $|0\\rangle$, don't change its state.\n",
-    "- If the qubit is in state $|1\\rangle$, change its state to $\\exp^{i\\alpha} |1\\rangle$.\n",
-    "- If the qubit is in superposition, change its state according to the effect on basis vectors.\n"
+    "- If the qubit is in state $|1\\rangle$, change its state to $e^{i\\alpha} |1\\rangle$.\n",
+    "- If the qubit is in superposition, change its state according to the effect on basis vectors: $\\beta |0\\rangle + \\color{red}{e^{i\\alpha}} \\gamma |1\\rangle$.\n"
    ]
   },
   {
@@ -251,7 +253,7 @@
    "source": [
     "%kata T16_PhaseChange_Test\n",
     "\n",
-    "operation PhaseChange (alpha : Double, q : Qubit) : Unit is Adj {\n",
+    "operation PhaseChange (alpha : Double, q : Qubit) : Unit is Adj+Ctl {\n",
     "    // ...\n",
     "}"
    ]
@@ -275,7 +277,7 @@
    "source": [
     "%kata T17_BellStateChange1_Test\n",
     "\n",
-    "operation BellStateChange1 (qs : Qubit[]) : Unit is Adj {\n",
+    "operation BellStateChange1 (qs : Qubit[]) : Unit is Adj+Ctl {\n",
     "    // ...\n",
     "}"
    ]
@@ -299,7 +301,7 @@
    "source": [
     "%kata T18_BellStateChange2_Test\n",
     "\n",
-    "operation BellStateChange2 (qs : Qubit[]) : Unit is Adj {\n",
+    "operation BellStateChange2 (qs : Qubit[]) : Unit is Adj+Ctl {\n",
     "    // ...\n",
     "}"
    ]
@@ -323,7 +325,7 @@
    "source": [
     "%kata T19_BellStateChange3_Test\n",
     "\n",
-    "operation BellStateChange3 (qs : Qubit[]) : Unit is Adj {\n",
+    "operation BellStateChange3 (qs : Qubit[]) : Unit is Adj+Ctl {\n",
     "    // ...\n",
     "}"
    ]
@@ -347,7 +349,7 @@
     "\n",
     "**Input:** Two unentangled qubits (stored in an array of length 2).\n",
     "The first qubit will be in state $|\\psi\\rangle = \\alpha |0\\rangle + \\beta |1\\rangle$, the second - in state $|0\\rangle$\n",
-    "(this can be written as two-qubit state  $\\big(\\alpha |0\\rangle + \\beta |1\\rangle \\big) \\otimes |0\\rangle$.\n",
+    "(this can be written as two-qubit state  $\\big(\\alpha |0\\rangle + \\beta |1\\rangle \\big) \\otimes |0\\rangle = \\alpha |00\\rangle + \\beta |10\\rangle$.\n",
     "\n",
     "\n",
     "**Goal:**  Change the two-qubit state to $\\alpha |00\\rangle + \\beta |11\\rangle$.\n",
@@ -376,7 +378,7 @@
    "source": [
     "### Task 2.2. Two-qubit gate - 2\n",
     "\n",
-    "**Input:** Two unentangled qubits (stored in an array of length 2) in state $|+\\rangle \\otimes |+\\rangle = \\frac{1}{2} \\big( |00\\rangle + |01\\rangle + |10\\rangle + |11\\rangle \\big)$.\n",
+    "**Input:** Two unentangled qubits (stored in an array of length 2) in state $|+\\rangle \\otimes |+\\rangle = \\frac{1}{2} \\big( |00\\rangle + |01\\rangle + |10\\rangle \\color{blue}+ |11\\rangle \\big)$.\n",
     "\n",
     "\n",
     "**Goal:**  Change the two-qubit state to $\\frac{1}{2} \\big( |00\\rangle + |01\\rangle + |10\\rangle \\color{red}- |11\\rangle \\big)$.\n",
@@ -404,7 +406,7 @@
    "source": [
     "### Task 2.3. Two-qubit gate - 3\n",
     "\n",
-    "**Input:** Two unentangled qubits (stored in an array of length 2) in an arbitrary two-qubit state $\\alpha |00\\rangle + \\beta |01\\rangle + \\gamma |10\\rangle + \\delta |11\\rangle$.\n",
+    "**Input:** Two unentangled qubits (stored in an array of length 2) in an arbitrary two-qubit state $\\alpha |00\\rangle + \\color{blue}\\beta |01\\rangle + \\color{blue}\\gamma |10\\rangle + \\delta |11\\rangle$.\n",
     "\n",
     "\n",
     "**Goal:**  Change the two-qubit state to $\\alpha |00\\rangle + \\color{red}\\gamma |01\\rangle + \\color{red}\\beta |10\\rangle + \\delta |11\\rangle$.\n",
@@ -432,7 +434,7 @@
     "### Task 2.4. Toffoli gate\n",
     "\n",
     "**Input:** Three qubits (stored in an array of length 3) in an arbitrary three-qubit state \n",
-    "$\\alpha |000\\rangle + \\beta |001\\rangle + \\gamma |010\\rangle + \\delta |011\\rangle + \\epsilon |100\\rangle + \\zeta|101\\rangle + \\eta|110\\rangle + \\theta|111\\rangle$.\n",
+    "$\\alpha |000\\rangle + \\beta |001\\rangle + \\gamma |010\\rangle + \\delta |011\\rangle + \\epsilon |100\\rangle + \\zeta|101\\rangle + \\color{blue}\\eta|110\\rangle + \\color{blue}\\theta|111\\rangle$.\n",
     "\n",
     "**Goal:** Flip the state of the third qubit if the state of the first two is $|11\\rangle$, i.e., change the three-qubit state to $\\alpha |000\\rangle + \\beta |001\\rangle + \\gamma |010\\rangle + \\delta |011\\rangle + \\epsilon |100\\rangle + \\zeta|101\\rangle + \\color{red}\\theta|110\\rangle + \\color{red}\\eta|111\\rangle$."
    ]
@@ -457,7 +459,7 @@
     "### Task 2.5. Fredkin gate\n",
     "\n",
     "**Input:** Three qubits (stored in an array of length 3) in an arbitrary three-qubit state \n",
-    "$\\alpha |000\\rangle + \\beta |001\\rangle + \\gamma |010\\rangle + \\delta |011\\rangle + \\epsilon |100\\rangle + \\zeta|101\\rangle + \\eta|110\\rangle + \\theta|111\\rangle$.\n",
+    "$\\alpha |000\\rangle + \\beta |001\\rangle + \\gamma |010\\rangle + \\delta |011\\rangle + \\epsilon |100\\rangle + \\color{blue}\\zeta|101\\rangle + \\color{blue}\\eta|110\\rangle + \\theta|111\\rangle$.\n",
     "\n",
     "**Goal:** Swap the states of second and third qubit if and only if the state of the first qubit is $|1\\rangle$, i.e., change the three-qubit state to $\\alpha |000\\rangle + \\beta |001\\rangle + \\gamma |010\\rangle + \\delta |011\\rangle + \\epsilon |100\\rangle + \\color{red}\\eta|101\\rangle + \\color{red}\\zeta|110\\rangle + \\theta|111\\rangle$."
    ]

--- a/BasicGates/ReferenceImplementation.qs
+++ b/BasicGates/ReferenceImplementation.qs
@@ -22,7 +22,7 @@ namespace Quantum.Kata.BasicGates {
     // Example:
     //     If the qubit is in state |0⟩, change its state to |1⟩.
     //     If the qubit is in state |1⟩, change its state to |0⟩.
-    operation StateFlip_Reference (q : Qubit) : Unit is Adj {
+    operation StateFlip_Reference (q : Qubit) : Unit is Adj+Ctl {
         X(q);
     }
 
@@ -34,7 +34,7 @@ namespace Quantum.Kata.BasicGates {
     //     If the qubit is in state |1⟩, change its state to |-⟩ = (|0⟩ - |1⟩) / sqrt(2).
     //     If the qubit is in superposition, change its state according to the effect on basis vectors.
     // Note: |+⟩ and |-⟩ form a different basis for single-qubit states, called X basis.
-    operation BasisChange_Reference (q : Qubit) : Unit is Adj {
+    operation BasisChange_Reference (q : Qubit) : Unit is Adj+Ctl {
         H(q);
     }
 
@@ -42,7 +42,7 @@ namespace Quantum.Kata.BasicGates {
     // Task 1.3. Sign flip: |+⟩ to |-⟩ and vice versa.
     // Inputs: A qubit in state |ψ⟩ = α |0⟩ + β |1⟩.
     // Goal: Change the qubit state to α |0⟩ - β |1⟩ (flip the sign of |1⟩ component of the superposition).
-    operation SignFlip_Reference (q : Qubit) : Unit is Adj {
+    operation SignFlip_Reference (q : Qubit) : Unit is Adj+Ctl {
         Z(q);
     }
 
@@ -55,7 +55,7 @@ namespace Quantum.Kata.BasicGates {
     //        If the qubit is in state |0⟩, change its state to cos(alpha)*|0⟩ + sin(alpha)*|1⟩.
     //        If the qubit is in state |1⟩, change its state to -sin(alpha)*|0⟩ + cos(alpha)*|1⟩.
     //        If the qubit is in superposition, change its state according to the effect on basis vectors.
-    operation AmplitudeChange_Reference (alpha : Double, q : Qubit) : Unit is Adj {
+    operation AmplitudeChange_Reference (alpha : Double, q : Qubit) : Unit is Adj+Ctl {
         Ry(2.0 * alpha, q);
     }
 
@@ -63,9 +63,9 @@ namespace Quantum.Kata.BasicGates {
     // Task 1.5. Phase flip
     // Input: A qubit in state |ψ⟩ = α |0⟩ + β |1⟩.
     // Goal:  Change the qubit state to α |0⟩ + iβ |1⟩ (flip the phase of |1⟩ component of the superposition).
-    operation PhaseFlip_Reference (q : Qubit) : Unit is Adj {
+    operation PhaseFlip_Reference (q : Qubit) : Unit is Adj+Ctl {
         S(q);
-        // alternatively Rz(0.5 * PI(), q);
+        // alternatively R1(0.5 * PI(), q);
     }
 
 
@@ -77,7 +77,7 @@ namespace Quantum.Kata.BasicGates {
     //        If the qubit is in state |0⟩, don't change its state.
     //        If the qubit is in state |1⟩, change its state to exp(i*alpha)|1⟩.
     //        If the qubit is in superposition, change its state according to the effect on basis vectors.
-    operation PhaseChange_Reference (alpha : Double, q : Qubit) : Unit is Adj {
+    operation PhaseChange_Reference (alpha : Double, q : Qubit) : Unit is Adj+Ctl {
         R1(alpha, q);
     }
 
@@ -85,7 +85,7 @@ namespace Quantum.Kata.BasicGates {
     // Task 1.7. Bell state change - 1
     // Input: Two entangled qubits in Bell state |Φ⁺⟩ = (|00⟩ + |11⟩) / sqrt(2).
     // Goal:  Change the two-qubit state to |Φ⁻⟩ = (|00⟩ - |11⟩) / sqrt(2).
-    operation BellStateChange1_Reference (qs : Qubit[]) : Unit is Adj {
+    operation BellStateChange1_Reference (qs : Qubit[]) : Unit is Adj+Ctl {
         Z(qs[0]);
         // alternatively Z(qs[1]);
     }
@@ -94,7 +94,7 @@ namespace Quantum.Kata.BasicGates {
     // Task 1.8. Bell state change - 2
     // Input: Two entangled qubits in Bell state |Φ⁺⟩ = (|00⟩ + |11⟩) / sqrt(2).
     // Goal:  Change the two-qubit state to |Ψ⁺⟩ = (|01⟩ + |10⟩) / sqrt(2).
-    operation BellStateChange2_Reference (qs : Qubit[]) : Unit is Adj {
+    operation BellStateChange2_Reference (qs : Qubit[]) : Unit is Adj+Ctl {
         X(qs[0]);
         // alternatively X(qs[1]);
     }
@@ -103,8 +103,10 @@ namespace Quantum.Kata.BasicGates {
     // Task 1.9. Bell state change - 3
     // Input: Two entangled qubits in Bell state |Φ⁺⟩ = (|00⟩ + |11⟩) / sqrt(2).
     // Goal:  Change the two-qubit state to |Ψ⁻⟩ = (|01⟩ - |10⟩) / sqrt(2).
-    operation BellStateChange3_Reference (qs : Qubit[]) : Unit is Adj {
-        Y(qs[0]);
+    operation BellStateChange3_Reference (qs : Qubit[]) : Unit is Adj+Ctl {
+        X(qs[0]);
+        Z(qs[0]);
+        // note that this is not equivalent to Y(qs[0]), since Y gate adds an extra global phase
     }
 
 

--- a/BasicGates/Tasks.qs
+++ b/BasicGates/Tasks.qs
@@ -40,9 +40,11 @@ namespace Quantum.Kata.BasicGates {
     //        If the qubit is in state |1⟩, change its state to |0⟩.
     // Note that this operation is self-adjoint: applying it for a second time
     // returns the qubit to the original state.
-    // `is Adj` at the end of the operation signature means that Q# will compute 
-    // the operation that returns the qubit to the original state automatically.
-    operation StateFlip (q : Qubit) : Unit is Adj {
+    //
+    // `is Adj+Ctl` at the end of the operation signature means that Q# will compute 
+    // the operation that returns the qubit to the original state 
+    // and the controlled version of the operation automatically.
+    operation StateFlip (q : Qubit) : Unit is Adj+Ctl {
         // The Pauli X gate will change the |0⟩ state to the |1⟩ state and vice versa.
         // Type X(q);
         // Then rebuild the project and rerun the tests - T11_StateFlip_Test should now pass!
@@ -58,7 +60,7 @@ namespace Quantum.Kata.BasicGates {
     //        If the qubit is in superposition, change its state according to the effect on basis vectors.
     // Note:  |+⟩ and |-⟩ form a different basis for single-qubit states, called X basis.
     // |0⟩ and |1⟩ are called Z basis.
-    operation BasisChange (q : Qubit) : Unit is Adj {
+    operation BasisChange (q : Qubit) : Unit is Adj+Ctl {
         // ...
     }
 
@@ -66,7 +68,7 @@ namespace Quantum.Kata.BasicGates {
     // Task 1.3. Sign flip: |+⟩ to |-⟩ and vice versa.
     // Input: A qubit in state |ψ⟩ = α |0⟩ + β |1⟩.
     // Goal:  Change the qubit state to α |0⟩ - β |1⟩ (flip the sign of |1⟩ component of the superposition).
-    operation SignFlip (q : Qubit) : Unit is Adj {
+    operation SignFlip (q : Qubit) : Unit is Adj+Ctl {
         // ...
     }
 
@@ -81,7 +83,7 @@ namespace Quantum.Kata.BasicGates {
     //        If the qubit is in superposition, change its state according to the effect on basis vectors.
     // This is the first operation in this kata that is not self-adjoint, 
     // i.e., applying it for a second time does not return the qubit to the original state. 
-    operation AmplitudeChange (alpha : Double, q : Qubit) : Unit is Adj {
+    operation AmplitudeChange (alpha : Double, q : Qubit) : Unit is Adj+Ctl {
         // ...
     }
 
@@ -89,7 +91,7 @@ namespace Quantum.Kata.BasicGates {
     // Task 1.5. Phase flip
     // Input: A qubit in state |ψ⟩ = α |0⟩ + β |1⟩.
     // Goal:  Change the qubit state to α |0⟩ + iβ |1⟩ (flip the phase of |1⟩ component of the superposition).
-    operation PhaseFlip (q : Qubit) : Unit is Adj {
+    operation PhaseFlip (q : Qubit) : Unit is Adj+Ctl {
         // ...
     }
 
@@ -102,7 +104,7 @@ namespace Quantum.Kata.BasicGates {
     //        If the qubit is in state |0⟩, don't change its state.
     //        If the qubit is in state |1⟩, change its state to exp(i*alpha)|1⟩.
     //        If the qubit is in superposition, change its state according to the effect on basis vectors.
-    operation PhaseChange (alpha : Double, q : Qubit) : Unit is Adj {
+    operation PhaseChange (alpha : Double, q : Qubit) : Unit is Adj+Ctl {
         // ...
     }
 
@@ -110,7 +112,7 @@ namespace Quantum.Kata.BasicGates {
     // Task 1.7. Bell state change - 1
     // Input: Two entangled qubits in Bell state |Φ⁺⟩ = (|00⟩ + |11⟩) / sqrt(2).
     // Goal:  Change the two-qubit state to |Φ⁻⟩ = (|00⟩ - |11⟩) / sqrt(2).
-    operation BellStateChange1 (qs : Qubit[]) : Unit is Adj {
+    operation BellStateChange1 (qs : Qubit[]) : Unit is Adj+Ctl {
         // ...
     }
 
@@ -118,7 +120,7 @@ namespace Quantum.Kata.BasicGates {
     // Task 1.8. Bell state change - 2
     // Input: Two entangled qubits in Bell state |Φ⁺⟩ = (|00⟩ + |11⟩) / sqrt(2).
     // Goal:  Change the two-qubit state to |Ψ⁺⟩ = (|01⟩ + |10⟩) / sqrt(2).
-    operation BellStateChange2 (qs : Qubit[]) : Unit is Adj {
+    operation BellStateChange2 (qs : Qubit[]) : Unit is Adj+Ctl {
         // ...
     }
 
@@ -126,7 +128,7 @@ namespace Quantum.Kata.BasicGates {
     // Task 1.9. Bell state change - 3
     // Input: Two entangled qubits in Bell state |Φ⁺⟩ = (|00⟩ + |11⟩) / sqrt(2).
     // Goal:  Change the two-qubit state to |Ψ⁻⟩ = (|01⟩ - |10⟩) / sqrt(2).
-    operation BellStateChange3 (qs : Qubit[]) : Unit is Adj {
+    operation BellStateChange3 (qs : Qubit[]) : Unit is Adj+Ctl {
         // ...
     }
 

--- a/BasicGates/Tasks.qs
+++ b/BasicGates/Tasks.qs
@@ -54,6 +54,7 @@ namespace Quantum.Kata.BasicGates {
         // ...
     }
 
+
     // Task 1.2. Basis change: |0⟩ to |+⟩ and |1⟩ to |-⟩ (and vice versa)
     // Input: A qubit in state |ψ⟩ = α |0⟩ + β |1⟩.
     // Goal:  Change the state of the qubit as follows:

--- a/BasicGates/Tasks.qs
+++ b/BasicGates/Tasks.qs
@@ -32,6 +32,12 @@ namespace Quantum.Kata.BasicGates {
     // Part I. Single-Qubit Gates
     //////////////////////////////////////////////////////////////////
 
+    // Note that all operations in this section have `is Adj+Ctl` in their signature.
+    // This means that they should be implemented in a way that allows Q# 
+    // to compute their adjoint and controlled variants automatically.
+    // Since each task is solved using only intrinsic gates, you should not need to put any special effort in this.
+
+
     // Task 1.1. State flip: |0⟩ to |1⟩ and vice versa
     // Input: A qubit in state |ψ⟩ = α |0⟩ + β |1⟩.
     // Goal:  Change the state of the qubit to α |1⟩ + β |0⟩.
@@ -40,10 +46,6 @@ namespace Quantum.Kata.BasicGates {
     //        If the qubit is in state |1⟩, change its state to |0⟩.
     // Note that this operation is self-adjoint: applying it for a second time
     // returns the qubit to the original state.
-    //
-    // `is Adj+Ctl` at the end of the operation signature means that Q# will compute 
-    // the operation that returns the qubit to the original state 
-    // and the controlled version of the operation automatically.
     operation StateFlip (q : Qubit) : Unit is Adj+Ctl {
         // The Pauli X gate will change the |0⟩ state to the |1⟩ state and vice versa.
         // Type X(q);

--- a/BasicGates/Tests.qs
+++ b/BasicGates/Tests.qs
@@ -9,6 +9,7 @@
 
 namespace Quantum.Kata.BasicGates {
     
+    open Microsoft.Quantum.Arrays;
     open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Canon;
     open Microsoft.Quantum.Convert;
@@ -18,26 +19,26 @@ namespace Quantum.Kata.BasicGates {
     
     // ------------------------------------------------------
     // helper wrapper to represent operation on one qubit as an operation on an array of qubits
-    operation ArrayWrapperOperation (op : (Qubit => Unit is Adj), qs : Qubit[]) : Unit is Adj {
-        op(qs[0]);
+    operation ArrayWrapperOperation (op : (Qubit => Unit is Adj+Ctl), qs : Qubit[]) : Unit is Adj+Ctl {
+        Controlled op([qs[0]], qs[1]);
     }
     
     
     // ------------------------------------------------------
     operation T11_StateFlip_Test () : Unit {
-        AssertOperationsEqualReferenced(1, ArrayWrapperOperation(StateFlip, _), ArrayWrapperOperation(StateFlip_Reference, _));
+        AssertOperationsEqualReferenced(2, ArrayWrapperOperation(StateFlip, _), ArrayWrapperOperation(StateFlip_Reference, _));
     }
     
     
     // ------------------------------------------------------
     operation T12_BasisChange_Test () : Unit {
-        AssertOperationsEqualReferenced(1, ArrayWrapperOperation(BasisChange, _), ArrayWrapperOperation(BasisChange_Reference, _));
+        AssertOperationsEqualReferenced(2, ArrayWrapperOperation(BasisChange, _), ArrayWrapperOperation(BasisChange_Reference, _));
     }
     
     
     // ------------------------------------------------------
     operation T13_SignFlip_Test () : Unit {
-        AssertOperationsEqualReferenced(1, ArrayWrapperOperation(SignFlip, _), ArrayWrapperOperation(SignFlip_Reference, _));
+        AssertOperationsEqualReferenced(2, ArrayWrapperOperation(SignFlip, _), ArrayWrapperOperation(SignFlip_Reference, _));
     }
     
     
@@ -45,14 +46,14 @@ namespace Quantum.Kata.BasicGates {
     operation T14_AmplitudeChange_Test () : Unit {
         for (i in 0 .. 36) {
             let alpha = ((2.0 * PI()) * IntAsDouble(i)) / 36.0;
-            AssertOperationsEqualReferenced(1, ArrayWrapperOperation(AmplitudeChange(alpha, _), _), ArrayWrapperOperation(AmplitudeChange_Reference(alpha, _), _));
+            AssertOperationsEqualReferenced(2, ArrayWrapperOperation(AmplitudeChange(alpha, _), _), ArrayWrapperOperation(AmplitudeChange_Reference(alpha, _), _));
         }
     }
     
     
     // ------------------------------------------------------
     operation T15_PhaseFlip_Test () : Unit {
-        AssertOperationsEqualReferenced(1, ArrayWrapperOperation(PhaseFlip, _), ArrayWrapperOperation(PhaseFlip_Reference, _));
+        AssertOperationsEqualReferenced(2, ArrayWrapperOperation(PhaseFlip, _), ArrayWrapperOperation(PhaseFlip_Reference, _));
     }
     
     
@@ -60,7 +61,7 @@ namespace Quantum.Kata.BasicGates {
     operation T16_PhaseChange_Test () : Unit {
         for (i in 0 .. 36) {
             let alpha = ((2.0 * PI()) * IntAsDouble(i)) / 36.0;
-            AssertOperationsEqualReferenced(1, ArrayWrapperOperation(PhaseChange(alpha, _), _), ArrayWrapperOperation(PhaseChange_Reference(alpha, _), _));
+            AssertOperationsEqualReferenced(2, ArrayWrapperOperation(PhaseChange(alpha, _), _), ArrayWrapperOperation(PhaseChange_Reference(alpha, _), _));
         }
     }
     
@@ -70,7 +71,7 @@ namespace Quantum.Kata.BasicGates {
     // 1 - |Φ⁻⟩ = (|00⟩ - |11⟩) / sqrt(2)
     // 2 - |Ψ⁺⟩ = (|01⟩ + |10⟩) / sqrt(2)
     // 3 - |Ψ⁻⟩ = (|01⟩ - |10⟩) / sqrt(2)
-    operation StatePrep_BellState (qs : Qubit[], state : Int) : Unit is Adj {
+    operation StatePrep_BellState (qs : Qubit[], state : Int) : Unit is Adj+Ctl {
         
         H(qs[0]);
         CNOT(qs[0], qs[1]);
@@ -88,17 +89,22 @@ namespace Quantum.Kata.BasicGates {
     
     
     // ------------------------------------------------------
-    operation VerifyBellStateConversion (testOp : (Qubit[] => Unit), startState : Int, targetState : Int) : Unit {
-        using (qs = Qubit[2]) {
+    operation VerifyBellStateConversion (testOp : (Qubit[] => Unit is Adj+Ctl), startState : Int, targetState : Int) : Unit {
+        // (note the use of controlled versions of operations to keep track of the phase potentially acquired by testOp)
+        using (qs = Qubit[3]) {
+            H(qs[0]);
+
             // prepare Bell state startState
-            StatePrep_BellState(qs, startState);
+            Controlled StatePrep_BellState([qs[0]], (Rest(qs), startState));
             
             // apply operation that needs to be tested
-            testOp(qs);
+            Controlled testOp([qs[0]], Rest(qs));
             
             // verify the result by applying adjoint of state prep for target state
-            Adjoint StatePrep_BellState(qs, targetState);
+            Controlled Adjoint StatePrep_BellState([qs[0]], (Rest(qs), targetState));
             
+            H(qs[0]);
+
             // assert that all qubits end up in |0⟩ state
             AssertAllZero(qs);
         }

--- a/BasicGates/Tests.qs
+++ b/BasicGates/Tests.qs
@@ -16,9 +16,19 @@ namespace Quantum.Kata.BasicGates {
     open Microsoft.Quantum.Math;
     open Microsoft.Quantum.Diagnostics;
     
-    
+    //////////////////////////////////////////////////////////////////
+    // Part I. Single-Qubit Gates
+    //////////////////////////////////////////////////////////////////
+
+    // The tests in part I are written to test controlled versions of operations instead of plain ones.
+    // This is done to verify that the tasks don't add a global phase to the implementations.
+    // Global phase is not relevant physically, but it can be very confusing for a beginner to consider R1 vs Rz,
+    // so the tests use controlled version of the operations which converts the global phase into a relative phase
+    // and makes it possible to detect.
+
     // ------------------------------------------------------
-    // helper wrapper to represent operation on one qubit as an operation on an array of qubits
+    // Helper wrapper to represent controlled variant of operation on one qubit 
+    // as an operation on an array of two qubits
     operation ArrayWrapperOperation (op : (Qubit => Unit is Adj+Ctl), qs : Qubit[]) : Unit is Adj+Ctl {
         Controlled op([qs[0]], qs[1]);
     }


### PR DESCRIPTION
As was pointed out in #146, task solutions which add extra global phase can be confusing for the learner. This change modifies the test harnesses for part I to check that the solutions do exactly the transformation required and to fail if the solution adds a global phase.