### PR TITLE
Superposition kata: Change signatures of single-qubit tasks

### DIFF
--- a/Superposition/ReferenceImplementation.qs
+++ b/Superposition/ReferenceImplementation.qs
@@ -20,40 +20,36 @@ namespace Quantum.Kata.Superposition {
     
     
     // Task 1. Plus state
-    // Input: a qubit in |0⟩ state (stored in an array of length 1).
-    // Goal: create a |+⟩ state on this qubit (|+⟩ = (|0⟩ + |1⟩) / sqrt(2)).
-    operation PlusState_Reference (qs : Qubit[]) : Unit 
-    is Adj {        
-        H(qs[0]);
+    // Input: a qubit in the |0⟩ state.
+    // Goal: prepare a |+⟩ state on this qubit (|+⟩ = (|0⟩ + |1⟩) / sqrt(2)).
+    operation PlusState_Reference (q : Qubit) : Unit is Adj {        
+        H(q);
     }
     
     
     // Task 2. Minus state
-    // Input: a qubit in |0⟩ state (stored in an array of length 1).
-    // Goal: create a |-⟩ state on this qubit (|-⟩ = (|0⟩ - |1⟩) / sqrt(2)).
-    operation MinusState_Reference (qs : Qubit[]) : Unit
-    is Adj {        
-        X(qs[0]);
-        H(qs[0]);
+    // Input: a qubit in the |0⟩ state.
+    // Goal: prepare a |-⟩ state on this qubit (|-⟩ = (|0⟩ - |1⟩) / sqrt(2)).
+    operation MinusState_Reference (q : Qubit) : Unit is Adj {        
+        X(q);
+        H(q);
     }
     
     
     // Task 3. Unequal superposition
     // Inputs:
-    //      1) a qubit in |0⟩ state (stored in an array of length 1).
+    //      1) a qubit in the |0⟩ state.
     //      2) angle alpha, in radians, represented as Double
-    // Goal: create a cos(alpha) * |0⟩ + sin(alpha) * |1⟩ state on this qubit.
-    operation UnequalSuperposition_Reference (qs : Qubit[], alpha : Double) : Unit
-    is Adj {        
+    // Goal: prepare a cos(alpha) * |0⟩ + sin(alpha) * |1⟩ state on this qubit.
+    operation UnequalSuperposition_Reference (q : Qubit, alpha : Double) : Unit is Adj {        
 
         // Hint: Experiment with rotation gates from Microsoft.Quantum.Intrinsic
-        Ry(2.0 * alpha, qs[0]);
+        Ry(2.0 * alpha, q);
     }
     
     
     // Task 4. Superposition of all basis vectors on two qubits
-    operation AllBasisVectors_TwoQubits_Reference (qs : Qubit[]) : Unit
-    is Adj {
+    operation AllBasisVectors_TwoQubits_Reference (qs : Qubit[]) : Unit is Adj {
 
         // Since a Hadamard gate will change |0⟩ into |+⟩ = (|0⟩ + |1⟩)/sqrt(2)
         // And the desired state is just a tensor product |+⟩|+⟩, we can apply
@@ -64,8 +60,7 @@ namespace Quantum.Kata.Superposition {
     
     
     // Task 5. Superposition of basis vectors with phases
-    operation AllBasisVectorsWithPhases_TwoQubits_Reference (qs : Qubit[]) : Unit
-    is Adj {
+    operation AllBasisVectorsWithPhases_TwoQubits_Reference (qs : Qubit[]) : Unit is Adj {
         
         // Question:
         // Is this state separable?
@@ -91,8 +86,7 @@ namespace Quantum.Kata.Superposition {
     // Task 6. Bell state
     // Input: two qubits in |00⟩ state (stored in an array of length 2).
     // Goal: create a Bell state |Φ⁺⟩ = (|00⟩ + |11⟩) / sqrt(2) on these qubits.
-    operation BellState_Reference (qs : Qubit[]) : Unit
-    is Adj {        
+    operation BellState_Reference (qs : Qubit[]) : Unit is Adj {        
         H(qs[0]);
         CNOT(qs[0], qs[1]);
     }
@@ -107,8 +101,7 @@ namespace Quantum.Kata.Superposition {
     //       1: |Φ⁻⟩ = (|00⟩ - |11⟩) / sqrt(2)
     //       2: |Ψ⁺⟩ = (|01⟩ + |10⟩) / sqrt(2)
     //       3: |Ψ⁻⟩ = (|01⟩ - |10⟩) / sqrt(2)
-    operation AllBellStates_Reference (qs : Qubit[], index : Int) : Unit
-    is Adj {
+    operation AllBellStates_Reference (qs : Qubit[], index : Int) : Unit is Adj {
         
         H(qs[0]);
         CNOT(qs[0], qs[1]);
@@ -127,8 +120,7 @@ namespace Quantum.Kata.Superposition {
     // Task 8. Greenberger–Horne–Zeilinger state
     // Input: N qubits in |0...0⟩ state.
     // Goal: create a GHZ state (|0...0⟩ + |1...1⟩) / sqrt(2) on these qubits.
-    operation GHZ_State_Reference (qs : Qubit[]) : Unit
-    is Adj {
+    operation GHZ_State_Reference (qs : Qubit[]) : Unit is Adj {
         
         H(qs[0]);
             
@@ -142,8 +134,7 @@ namespace Quantum.Kata.Superposition {
     // Input: N qubits in |0...0⟩ state.
     // Goal: create an equal superposition of all basis vectors from |0...0⟩ to |1...1⟩
     // (i.e. state (|0...0⟩ + ... + |1...1⟩) / sqrt(2^N) ).
-    operation AllBasisVectorsSuperposition_Reference (qs : Qubit[]) : Unit
-    is Adj {
+    operation AllBasisVectorsSuperposition_Reference (qs : Qubit[]) : Unit is Adj {
         
         for (q in qs) {
             H(q);
@@ -155,8 +146,7 @@ namespace Quantum.Kata.Superposition {
     // Task 10. |00⟩ + |01⟩ + |10⟩ state
     // Input: 2 qubits in |00⟩ state.
     // Goal: create the state (|00⟩ + |01⟩ + |10⟩) / sqrt(3) on these qubits.
-    operation ThreeStates_TwoQubits_Reference (qs : Qubit[]) : Unit
-    is Adj {
+    operation ThreeStates_TwoQubits_Reference (qs : Qubit[]) : Unit is Adj {
         
         // Follow Niel's answer at https://quantumcomputing.stackexchange.com/a/2313/
             
@@ -196,8 +186,7 @@ namespace Quantum.Kata.Superposition {
     // You are guaranteed that the qubit array and the bit string have the same length.
     // You are guaranteed that the first bit of the bit string is true.
     // Example: for bit string = [true, false] the qubit state required is (|00⟩ + |10⟩) / sqrt(2).
-    operation ZeroAndBitstringSuperposition_Reference (qs : Qubit[], bits : Bool[]) : Unit
-    is Adj {
+    operation ZeroAndBitstringSuperposition_Reference (qs : Qubit[], bits : Bool[]) : Unit is Adj {
         
         EqualityFactI(Length(bits), Length(qs), "Arrays should have the same length");
         EqualityFactB(bits[0], true, "First bit of the input bit string should be set to true");
@@ -237,8 +226,7 @@ namespace Quantum.Kata.Superposition {
     }
     
     
-    operation TwoBitstringSuperposition_Reference (qs : Qubit[], bits1 : Bool[], bits2 : Bool[]) : Unit
-    is Adj {
+    operation TwoBitstringSuperposition_Reference (qs : Qubit[], bits1 : Bool[], bits2 : Bool[]) : Unit is Adj {
         
         // find the index of the first bit at which the bit strings are different
         let firstDiff = FindFirstDiff_Reference(bits1, bits2);
@@ -276,8 +264,7 @@ namespace Quantum.Kata.Superposition {
     //         bit values false and true correspond to |0⟩ and |1⟩ states.
     //
     // Goal: create an equal superposition of the four basis states given by the bit strings.
-    operation FourBitstringSuperposition_Reference (qs : Qubit[], bits : Bool[][]) : Unit
-    is Adj {
+    operation FourBitstringSuperposition_Reference (qs : Qubit[], bits : Bool[][]) : Unit is Adj {
         let N = Length(qs);
             
         using (anc = Qubit[2]) {
@@ -312,8 +299,7 @@ namespace Quantum.Kata.Superposition {
     // Goal: create a W state (https://en.wikipedia.org/wiki/W_state) on these qubits.
     // W state is an equal superposition of all basis states on N qubits of Hamming weight 1.
     // Example: for N = 4, W state is (|1000⟩ + |0100⟩ + |0010⟩ + |0001⟩) / 2.
-    operation WState_PowerOfTwo_Reference (qs : Qubit[]) : Unit
-    is Adj {
+    operation WState_PowerOfTwo_Reference (qs : Qubit[]) : Unit is Adj {
         
         let N = Length(qs);
             
@@ -350,8 +336,7 @@ namespace Quantum.Kata.Superposition {
     // Example: for N = 3, W state is (|100⟩ + |010⟩ + |001⟩) / sqrt(3).
     
     // general solution based on rotations and recursive application of controlled generation routine
-    operation WState_Arbitrary_Reference (qs : Qubit[]) : Unit
-    is Adj + Ctl {
+    operation WState_Arbitrary_Reference (qs : Qubit[]) : Unit is Adj + Ctl {
         
         let N = Length(qs);
             
@@ -375,7 +360,7 @@ namespace Quantum.Kata.Superposition {
 
     // Iterative solution (equivalent to the WState_Arbitrary_Reference, but with the recursion unrolled)
     // Circuit for N=4: https://algassert.com/quirk#circuit={%22cols%22:[[1,1,1,%22~95cq%22],[1,1,%22~erlf%22,%22%E2%97%A6%22],[1,%22~809j%22,%22%E2%97%A6%22,%22%E2%97%A6%22],[%22X%22,%22%E2%97%A6%22,%22%E2%97%A6%22,%22%E2%97%A6%22]],%22gates%22:[{%22id%22:%22~809j%22,%22name%22:%22FS_2%22,%22matrix%22:%22{{%E2%88%9A%C2%BD,-%E2%88%9A%C2%BD},{%E2%88%9A%C2%BD,%E2%88%9A%C2%BD}}%22},{%22id%22:%22~erlf%22,%22name%22:%22FS_3%22,%22matrix%22:%22{{%E2%88%9A%E2%85%94,-%E2%88%9A%E2%85%93},{%E2%88%9A%E2%85%93,%E2%88%9A%E2%85%94}}%22},{%22id%22:%22~95cq%22,%22name%22:%22FS_4%22,%22matrix%22:%22{{%E2%88%9A%C2%BE,-%C2%BD},{%C2%BD,%E2%88%9A%C2%BE}}%22}]}
-    operation WState_Arbitrary_Iterative (qs : Qubit[]) : Unit {
+    operation WState_Arbitrary_Iterative (qs : Qubit[]) : Unit is Adj {
         let N = Length(qs);
         FractionSuperposition(N, qs[0]);
         for (i in 1 .. N - 1) {
@@ -385,8 +370,7 @@ namespace Quantum.Kata.Superposition {
     
     // Given a qubit in |0⟩ state and a denominator N,
     // transform the qubit to state sqrt((N-1) / N) |0⟩ + sqrt(1/N) |1⟩.
-    operation FractionSuperposition(denominator : Int, q : Qubit) : Unit
-    is Adj + Ctl {
+    operation FractionSuperposition(denominator : Int, q : Qubit) : Unit is Adj + Ctl {
 
         if (denominator == 1) {
             X(q);
@@ -432,7 +416,9 @@ namespace Quantum.Kata.Superposition {
                         // measure ancilla qubits; if all of the results are Zero, we get the right state on main qubits
                         mutable allZeros = true;
                         for (i in 0 .. (P - N) - 1) {
-                            set allZeros = allZeros and IsResultZero(M(anc[i]));
+                            if (not IsResultZero(M(anc[i]))) {
+                                set allZeros = false;
+                            }
                         }
                     }
                     until (allZeros)

--- a/Superposition/Superposition.ipynb
+++ b/Superposition/Superposition.ipynb
@@ -64,7 +64,7 @@
    "source": [
     "### Task 1. Plus state.\n",
     "\n",
-    "**Input:** A qubit in the $|0\\rangle$ state (stored in an array of length 1).\n",
+    "**Input:** A qubit in the $|0\\rangle$ state.\n",
     "\n",
     "**Goal:**  Change the state of the qubit to $|+\\rangle = \\frac{1}{\\sqrt{2}} \\big(|0\\rangle + |1\\rangle\\big)$."
    ]
@@ -77,10 +77,9 @@
    "source": [
     "%kata T01_PlusState_Test \n",
     "\n",
-    "operation PlusState (qs : Qubit[]) : Unit {\n",
+    "operation PlusState (q : Qubit) : Unit {\n",
     "    // Hadamard gate H will convert |0⟩ state to |+⟩ state.\n",
-    "    // The first qubit of the array can be accessed as qs[0].\n",
-    "    // Type the following: H(qs[0]);\n",
+    "    // Type the following: H(q);\n",
     "    // Then run the cell using Ctrl/⌘+Enter.\n",
     "\n",
     "    // ...\n",
@@ -93,7 +92,7 @@
    "source": [
     "### Task 2. Minus state\n",
     "\n",
-    "**Input**: A qubit in the $|0\\rangle$ state (stored in an array of length 1).\n",
+    "**Input**: A qubit in the $|0\\rangle$ state.\n",
     "\n",
     "**Goal**:  Change the state of the qubit to $|-\\rangle = \\frac{1}{\\sqrt{2}} \\big(|0\\rangle - |1\\rangle\\big)$."
    ]
@@ -106,7 +105,7 @@
    "source": [
     "%kata T02_MinusState_Test \n",
     "\n",
-    "operation MinusState (qs : Qubit[]) : Unit {\n",
+    "operation MinusState (q : Qubit) : Unit {\n",
     "    // ...\n",
     "}"
    ]
@@ -119,7 +118,7 @@
     "\n",
     "**Inputs:**\n",
     "\n",
-    "1. A qubit in the $|0\\rangle$ state (stored in an array of length 1).\n",
+    "1. A qubit in the $|0\\rangle$ state.\n",
     "2. Angle α, in radians, represented as Double.\n",
     "\n",
     "**Goal** : Change the state of the qubit to $\\cos{α} |0\\rangle + \\sin{α} |1\\rangle$.\n",
@@ -140,7 +139,7 @@
    "source": [
     "%kata T03_UnequalSuperposition_Test \n",
     "\n",
-    "operation UnequalSuperposition (qs : Qubit[], alpha : Double) : Unit {\n",
+    "operation UnequalSuperposition (q : Qubit, alpha : Double) : Unit {\n",
     "    // ...\n",
     "}"
    ]
@@ -238,10 +237,30 @@
     "\n",
     "**Goal:**  Change the state of the qubits to one of the Bell states, based on the value of index:\n",
     "\n",
-    "* 0 - $|\\Phi^{+}\\rangle = \\frac{1}{\\sqrt{2}} \\big (|00\\rangle + |11\\rangle\\big)$,\n",
-    "* 1 - $|\\Phi^{-}\\rangle = \\frac{1}{\\sqrt{2}} \\big (|00\\rangle - |11\\rangle\\big)$,\n",
-    "* 2 - $|\\Psi^{+}\\rangle = \\frac{1}{\\sqrt{2}} \\big (|01\\rangle + |10\\rangle\\big)$,\n",
-    "* 3 - $|\\Psi^{-}\\rangle = \\frac{1}{\\sqrt{2}} \\big (|01\\rangle - |10\\rangle\\big)$."
+    "<table>\n",
+    "  <col width=\"50\"/>\n",
+    "  <col width=\"200\"/>\n",
+    "  <tr>\n",
+    "    <th style=\"text-align:center\">Index</th>\n",
+    "    <th style=\"text-align:center\">State</th>\n",
+    "  </tr>\n",
+    "  <tr>\n",
+    "    <td style=\"text-align:center\">0</td>\n",
+    "    <td style=\"text-align:center\">$|\\Phi^{+}\\rangle = \\frac{1}{\\sqrt{2}} \\big (|00\\rangle + |11\\rangle\\big)$</td>\n",
+    "  </tr>\n",
+    "  <tr>\n",
+    "    <td style=\"text-align:center\">1</td>\n",
+    "    <td style=\"text-align:center\">$|\\Phi^{-}\\rangle = \\frac{1}{\\sqrt{2}} \\big (|00\\rangle - |11\\rangle\\big)$</td>\n",
+    "  </tr>\n",
+    "  <tr>\n",
+    "    <td style=\"text-align:center\">2</td>\n",
+    "    <td style=\"text-align:center\">$|\\Psi^{+}\\rangle = \\frac{1}{\\sqrt{2}} \\big (|01\\rangle + |10\\rangle\\big)$</td>\n",
+    "  </tr>\n",
+    "  <tr>\n",
+    "    <td style=\"text-align:center\">3</td>\n",
+    "    <td style=\"text-align:center\">$|\\Psi^{-}\\rangle = \\frac{1}{\\sqrt{2}} \\big (|01\\rangle - |10\\rangle\\big)$</td>\n",
+    "  </tr>\n",
+    "</table>"
    ]
   },
   {

--- a/Superposition/Tasks.qs
+++ b/Superposition/Tasks.qs
@@ -29,12 +29,11 @@ namespace Quantum.Kata.Superposition {
     // The tasks are given in approximate order of increasing difficulty; harder ones are marked with asterisks.
     
     // Task 1. Plus state
-    // Input: a qubit in |0⟩ state (stored in an array of length 1).
-    // Goal: create a |+⟩ state on this qubit (|+⟩ = (|0⟩ + |1⟩) / sqrt(2)).
-    operation PlusState (qs : Qubit[]) : Unit {
+    // Input: a qubit in the |0⟩ state.
+    // Goal: prepare a |+⟩ state on this qubit (|+⟩ = (|0⟩ + |1⟩) / sqrt(2)).
+    operation PlusState (q : Qubit) : Unit {
         // Hadamard gate H will convert |0⟩ state to |+⟩ state.
-        // The first qubit of the array can be accessed as qs[0].
-        // Type the following: H(qs[0]);
+        // Type the following: H(q);
         // Then rebuild the project and rerun the tests - T01_PlusState_Test should now pass!
 
         // ...
@@ -42,9 +41,9 @@ namespace Quantum.Kata.Superposition {
     
     
     // Task 2. Minus state
-    // Input: a qubit in |0⟩ state (stored in an array of length 1).
-    // Goal: create a |-⟩ state on this qubit (|-⟩ = (|0⟩ - |1⟩) / sqrt(2)).
-    operation MinusState (qs : Qubit[]) : Unit {
+    // Input: a qubit in the |0⟩ state.
+    // Goal: prepare a |-⟩ state on this qubit (|-⟩ = (|0⟩ - |1⟩) / sqrt(2)).
+    operation MinusState (q : Qubit) : Unit {
         // In this task, as well as in all subsequent ones, you have to come up with the solution yourself.
             
         // ...
@@ -53,10 +52,10 @@ namespace Quantum.Kata.Superposition {
     
     // Task 3*. Unequal superposition
     // Inputs:
-    //      1) a qubit in |0⟩ state (stored in an array of length 1).
-    //      2) angle alpha, in radians, represented as Double
-    // Goal: create a cos(alpha) * |0⟩ + sin(alpha) * |1⟩ state on this qubit.
-    operation UnequalSuperposition (qs : Qubit[], alpha : Double) : Unit {
+    //      1) a qubit in the |0⟩ state.
+    //      2) angle alpha, in radians, represented as Double.
+    // Goal: prepare a cos(alpha) * |0⟩ + sin(alpha) * |1⟩ state on this qubit.
+    operation UnequalSuperposition (q : Qubit, alpha : Double) : Unit {
         // Hint: Experiment with rotation gates from the Microsoft.Quantum.Intrinsic namespace.
         // Note that all rotation operators rotate the state by _half_ of its angle argument.
 

--- a/Superposition/Tests.qs
+++ b/Superposition/Tests.qs
@@ -32,29 +32,38 @@ namespace Quantum.Kata.Superposition {
     
     
     // ------------------------------------------------------
+    operation ArrayWrapperOperation (op : (Qubit => Unit), qs : Qubit[]) : Unit {
+        op(qs[0]);
+    }
+
+    operation ArrayWrapperOperationA (op : (Qubit => Unit is Adj), qs : Qubit[]) : Unit is Adj {
+        op(qs[0]);
+    }
+
+
     operation T01_PlusState_Test () : Unit {
-        AssertEqualOnZeroState(1, PlusState, PlusState_Reference);
+        AssertEqualOnZeroState(1, ArrayWrapperOperation(PlusState, _), ArrayWrapperOperationA(PlusState_Reference, _));
     }
     
     
     // ------------------------------------------------------
     operation T02_MinusState_Test () : Unit {
-        AssertEqualOnZeroState(1, MinusState, MinusState_Reference);
+        AssertEqualOnZeroState(1, ArrayWrapperOperation(MinusState, _), ArrayWrapperOperationA(MinusState_Reference, _));
     }
     
     
     // ------------------------------------------------------
     operation T03_UnequalSuperposition_Test () : Unit {
         // cross-test
-        AssertEqualOnZeroState(1, UnequalSuperposition(_, 0.0), ApplyToEachA(I, _));
-        AssertEqualOnZeroState(1, UnequalSuperposition(_, 0.5 * PI()), ApplyToEachA(X, _));
-        AssertEqualOnZeroState(1, UnequalSuperposition(_, 0.5 * PI()), ApplyToEachA(Y, _));
-        AssertEqualOnZeroState(1, UnequalSuperposition(_, 0.25 * PI()), PlusState_Reference);
-        AssertEqualOnZeroState(1, UnequalSuperposition(_, 0.75 * PI()), MinusState_Reference);
+        AssertEqualOnZeroState(1, ArrayWrapperOperation(UnequalSuperposition(_, 0.0), _), ApplyToEachA(I, _));
+        AssertEqualOnZeroState(1, ArrayWrapperOperation(UnequalSuperposition(_, 0.5 * PI()), _), ApplyToEachA(X, _));
+        AssertEqualOnZeroState(1, ArrayWrapperOperation(UnequalSuperposition(_, 0.5 * PI()), _), ApplyToEachA(Y, _));
+        AssertEqualOnZeroState(1, ArrayWrapperOperation(UnequalSuperposition(_, 0.25 * PI()), _), ArrayWrapperOperationA(PlusState_Reference, _));
+        AssertEqualOnZeroState(1, ArrayWrapperOperation(UnequalSuperposition(_, 0.75 * PI()), _), ArrayWrapperOperationA(MinusState_Reference, _));
         
         for (i in 1 .. 36) {
             let alpha = ((2.0 * PI()) * IntAsDouble(i)) / 36.0;
-            AssertEqualOnZeroState(1, UnequalSuperposition(_, alpha), UnequalSuperposition_Reference(_, alpha));
+            AssertEqualOnZeroState(1, ArrayWrapperOperation(UnequalSuperposition(_, alpha), _), ArrayWrapperOperationA(UnequalSuperposition_Reference(_, alpha), _));
         }
     }
     
@@ -90,7 +99,7 @@ namespace Quantum.Kata.Superposition {
     // ------------------------------------------------------
     operation T08_GHZ_State_Test () : Unit {
         // for N = 1 it's just |+⟩
-        AssertEqualOnZeroState(1, GHZ_State, PlusState_Reference);
+        AssertEqualOnZeroState(1, GHZ_State, ArrayWrapperOperationA(PlusState_Reference, _));
         
         // for N = 2 it's Bell state
         AssertEqualOnZeroState(2, GHZ_State, BellState_Reference);
@@ -104,7 +113,7 @@ namespace Quantum.Kata.Superposition {
     // ------------------------------------------------------
     operation T09_AllBasisVectorsSuperposition_Test () : Unit {
         // for N = 1 it's just |+⟩
-        AssertEqualOnZeroState(1, AllBasisVectorsSuperposition, PlusState_Reference);
+        AssertEqualOnZeroState(1, AllBasisVectorsSuperposition, ArrayWrapperOperationA(PlusState_Reference, _));
         
         for (n in 2 .. 9) {
             AssertEqualOnZeroState(n, AllBasisVectorsSuperposition, AllBasisVectorsSuperposition_Reference);
@@ -121,7 +130,7 @@ namespace Quantum.Kata.Superposition {
     // ------------------------------------------------------
     operation T11_ZeroAndBitstringSuperposition_Test () : Unit {
         // compare with results of previous operations
-        AssertEqualOnZeroState(1, ZeroAndBitstringSuperposition(_, [true]), PlusState_Reference);
+        AssertEqualOnZeroState(1, ZeroAndBitstringSuperposition(_, [true]), ArrayWrapperOperationA(PlusState_Reference, _));
         AssertEqualOnZeroState(2, ZeroAndBitstringSuperposition(_, [true, true]), BellState_Reference);
         AssertEqualOnZeroState(3, ZeroAndBitstringSuperposition(_, [true, true, true]), GHZ_State_Reference);
         
@@ -139,7 +148,7 @@ namespace Quantum.Kata.Superposition {
     // ------------------------------------------------------
     operation T12_TwoBitstringSuperposition_Test () : Unit {
         // compare with results of previous operations
-        AssertEqualOnZeroState(1, TwoBitstringSuperposition(_, [true], [false]), PlusState_Reference);
+        AssertEqualOnZeroState(1, TwoBitstringSuperposition(_, [true], [false]), ArrayWrapperOperationA(PlusState_Reference, _));
         AssertEqualOnZeroState(2, TwoBitstringSuperposition(_, [false, false], [true, true]), BellState_Reference);
         AssertEqualOnZeroState(3, TwoBitstringSuperposition(_, [true, true, true], [false, false, false]), GHZ_State_Reference);
         


### PR DESCRIPTION
It does not really make sense to use qubit arrays for single-qubit tasks, and switching them to single-qubit signatures makes the first three tasks a bit more palatable.

I also switched the Notebook presentation from a list to a table; it makes for a lengthy code but in the end the table looks much nicer.