### PR TITLE
QEC_BitFlipCode: Add check for the number of measurements used in task 1

### DIFF
--- a/Measurements/Measurements.ipynb
+++ b/Measurements/Measurements.ipynb
@@ -23,7 +23,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To begin, first prepare this notebook for execution (if you skip the first step, you'll get \"Syntax does not match any known patterns\" error when you try to execute Q# code in the next cells; if you skip the second step, you'll get \"Invalid kata name\" error):"
+    "To begin, first prepare this notebook for execution (if you skip the first step, you'll get \"Syntax does not match any known patterns\" error when you try to execute Q# code in the next cells; if you skip the second step, you'll get \"Invalid test name\" error):"
    ]
   },
   {

--- a/QEC_BitFlipCode/QEC_BitFlipCode.csproj
+++ b/QEC_BitFlipCode/QEC_BitFlipCode.csproj
@@ -17,4 +17,8 @@
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\utilities\Common\Common.csproj" />
+  </ItemGroup>
 </Project>

--- a/QEC_BitFlipCode/QEC_BitFlipCode.ipynb
+++ b/QEC_BitFlipCode/QEC_BitFlipCode.ipynb
@@ -19,7 +19,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To begin, first prepare this notebook for execution (if you skip this step, you'll get \"Syntax does not match any known patterns\" error when you try to execute Q# code in the next cells):"
+    "To begin, first prepare this notebook for execution (if you skip this step, you'll get \"Syntax does not match any known patterns\" error when you try to execute Q# code in the next cells; if you skip the second step, you'll get \"Invalid test name\" error):"
    ]
   },
   {
@@ -52,6 +52,15 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%workspace reload"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -59,7 +68,7 @@
     "\n",
     "**Input:** three qubits (stored as an array of length 3) in an unknown basis state or in a superposition of basis states of the same parity.\n",
     "\n",
-    "**Output:** the parity of this state encoded as a value of `Result` type: `Zero` for parity 0 and `One` for parity 1.  The parity of basis state $| x_{0} x_{1} x_{2}\\rangle$ is defined as $(x_{0} \\otimes x_{1} \\otimes x_{2})$.  After applying the operation the state of the qubits should not change. You can use exactly one call to `Measure`.\n",
+    "**Output:** the parity of this state encoded as a value of `Result` type: `Zero` for parity 0 and `One` for parity 1.  The parity of basis state $| x_{0} x_{1} x_{2}\\rangle$ is defined as $(x_{0} \\otimes x_{1} \\otimes x_{2})$.  After applying the operation the state of the qubits should not change. You can use exactly one measurement.\n",
     "    \n",
     "**Example:** $|000 \\rangle$, $|101\\rangle$ and $|011\\rangle$ all have parity 0, while $|010\\rangle$ and $|111\\rangle$ have parity 1."
    ]

--- a/QEC_BitFlipCode/QEC_BitFlipCode.ipynb
+++ b/QEC_BitFlipCode/QEC_BitFlipCode.ipynb
@@ -83,7 +83,7 @@
     "\n",
     "operation MeasureParity (register : Qubit[]) : Result {\n",
     "    // ...\n",
-    "    return ...;\n",
+    "    return Zero;\n",
     "}"
    ]
   },

--- a/QEC_BitFlipCode/QEC_BitFlipCode.sln
+++ b/QEC_BitFlipCode/QEC_BitFlipCode.sln
@@ -4,6 +4,8 @@ VisualStudioVersion = 15.0.26124.0
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "QEC_BitFlipCode", "QEC_BitFlipCode.csproj", "{74AE1DA0-0B82-46C3-8E5D-2B2FF94DDAB4}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Common", "..\utilities\Common\Common.csproj", "{33756153-102C-4122-9ED9-424EA4D46409}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -26,6 +28,18 @@ Global
 		{74AE1DA0-0B82-46C3-8E5D-2B2FF94DDAB4}.Release|x64.Build.0 = Release|Any CPU
 		{74AE1DA0-0B82-46C3-8E5D-2B2FF94DDAB4}.Release|x86.ActiveCfg = Release|Any CPU
 		{74AE1DA0-0B82-46C3-8E5D-2B2FF94DDAB4}.Release|x86.Build.0 = Release|Any CPU
+		{33756153-102C-4122-9ED9-424EA4D46409}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{33756153-102C-4122-9ED9-424EA4D46409}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{33756153-102C-4122-9ED9-424EA4D46409}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{33756153-102C-4122-9ED9-424EA4D46409}.Debug|x64.Build.0 = Debug|Any CPU
+		{33756153-102C-4122-9ED9-424EA4D46409}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{33756153-102C-4122-9ED9-424EA4D46409}.Debug|x86.Build.0 = Debug|Any CPU
+		{33756153-102C-4122-9ED9-424EA4D46409}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{33756153-102C-4122-9ED9-424EA4D46409}.Release|Any CPU.Build.0 = Release|Any CPU
+		{33756153-102C-4122-9ED9-424EA4D46409}.Release|x64.ActiveCfg = Release|Any CPU
+		{33756153-102C-4122-9ED9-424EA4D46409}.Release|x64.Build.0 = Release|Any CPU
+		{33756153-102C-4122-9ED9-424EA4D46409}.Release|x86.ActiveCfg = Release|Any CPU
+		{33756153-102C-4122-9ED9-424EA4D46409}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/QEC_BitFlipCode/Tasks.qs
+++ b/QEC_BitFlipCode/Tasks.qs
@@ -36,7 +36,7 @@ namespace Quantum.Kata.QEC_BitFlipCode {
     //         Zero for parity 0 and One for parity 1.
     //         The parity of basis state |x₀x₁x₂⟩ is defined as (x₀ ⊕ x₁ ⊕ x₂).
     // After applying the operation the state of the qubits should not change.
-    // You can use exactly one call to Measure.
+    // You can use exactly one measurement.
     // 
     // Example:
     // |000⟩, |101⟩ and |011⟩ all have parity 0, while |010⟩ and |111⟩ have parity 1.

--- a/QEC_BitFlipCode/TestSuiteRunner.cs
+++ b/QEC_BitFlipCode/TestSuiteRunner.cs
@@ -8,9 +8,10 @@
 //////////////////////////////////////////////////////////////////////
 
 using Microsoft.Quantum.Simulation.XUnit;
-using Microsoft.Quantum.Simulation.Simulators;
 using Xunit.Abstractions;
 using System.Diagnostics;
+
+using Microsoft.Quantum.Katas;
 
 namespace Quantum.Kata.QEC_BitFlipCode
 {
@@ -30,7 +31,7 @@ namespace Quantum.Kata.QEC_BitFlipCode
         [OperationDriver(TestNamespace = "Quantum.Kata.QEC_BitFlipCode")]
         public void TestTarget(TestOperation op)
         {
-            using (var sim = new QuantumSimulator())
+            using (var sim = new CounterSimulator())
             {
                 // OnLog defines action(s) performed when Q# test calls function Message
                 sim.OnLog += (msg) => { output.WriteLine(msg); };

--- a/QEC_BitFlipCode/Tests.qs
+++ b/QEC_BitFlipCode/Tests.qs
@@ -98,14 +98,14 @@ namespace Quantum.Kata.QEC_BitFlipCode {
             let res = MeasureParity(register);
             
             // check that the returned parity is correct
-            EqualityFactB(res == Zero, parity == 0, $"Failed on {stateStr}.");
+            Fact((res == Zero) == (parity == 0), $"Failed on {stateStr}.");
             
             // check that the state has not been modified
             Adjoint statePrep(register);
             AssertAllZero(register);
 
             let nm = GetOracleCallsCount(M) + GetOracleCallsCount(Measure);
-            AssertBoolEqual(nm <= 1, true, $"You are allowed to do at most one measurement, and you did {nm}");
+            Fact(nm <= 1, $"You are allowed to do at most one measurement, and you did {nm}");
         }
     }
     

--- a/QEC_BitFlipCode/Tests.qs
+++ b/QEC_BitFlipCode/Tests.qs
@@ -17,6 +17,7 @@ namespace Quantum.Kata.QEC_BitFlipCode {
     open Microsoft.Quantum.Math;
     open Microsoft.Quantum.Bitwise;
     
+    open Quantum.Kata.Utils;
     
     //////////////////////////////////////////////////////////////////////////
     // Task 01
@@ -91,6 +92,9 @@ namespace Quantum.Kata.QEC_BitFlipCode {
         using (register = Qubit[3]) {
             // prepare basis state to test on
             statePrep(register);
+
+            ResetOracleCallsCount();
+
             let res = MeasureParity(register);
             
             // check that the returned parity is correct
@@ -99,6 +103,9 @@ namespace Quantum.Kata.QEC_BitFlipCode {
             // check that the state has not been modified
             Adjoint statePrep(register);
             AssertAllZero(register);
+
+            let nm = GetOracleCallsCount(M) + GetOracleCallsCount(Measure);
+            AssertBoolEqual(nm <= 1, true, $"You are allowed to do at most one measurement, and you did {nm}");
         }
     }
     


### PR DESCRIPTION
This fixes an issue similar to #68: the task requires to use only one measurement but doesn't enforce this requirement in the testing harness.