### PR TITLE
JointMeasurements: Restrict the use of multi-qubit gates in tasks 6 and 7

### DIFF
--- a/JointMeasurements/JointMeasurements.csproj
+++ b/JointMeasurements/JointMeasurements.csproj
@@ -19,4 +19,8 @@
   <ItemGroup>
     <None Include="README.md" />
   </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\utilities\Common\Common.csproj" />
+  </ItemGroup>
 </Project>

--- a/JointMeasurements/JointMeasurements.ipynb
+++ b/JointMeasurements/JointMeasurements.ipynb
@@ -54,6 +54,15 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%workspace reload"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -220,7 +229,7 @@
    "source": [
     "### Task 7**. Controlled X gate with arbitrary target\n",
     "\n",
-    "**Input:** Two qubits (stored in an array of length 2) in an arbitrary two-qubit state $\\alpha |00\\rangle + \\beta |01\\rangle + \\gamma |10\\rangle  + \\delta |11\\rangle$.\n",
+    "**Input:** Two qubits (stored in an array of length 2) in an arbitrary two-qubit state $\\alpha |00\\rangle + \\beta |01\\rangle + \\color{blue}\\gamma |10\\rangle  + \\color{blue}\\delta |11\\rangle$.\n",
     "\n",
     "**Goal:** Change the two-qubit state to $\\alpha |00\\rangle + \\beta |01\\rangle + \\color{red}\\delta |10\\rangle  + \\color{red}\\gamma |11\\rangle$ using only single-qubit gates and joint measurements.  Do not use two-qubit gates.\n",
     "\n",
@@ -241,12 +250,7 @@
     "%kata T07_ControlledX_General_Test\n",
     "\n",
     "operation ControlledX_General (qs : Qubit[]) : Unit {\n",
-    "        \n",
-    "    body (...) {\n",
-    "        // ...\n",
-    "    }\n",
-    "\n",
-    "    adjoint self;\n",
+    "    // ...\n",
     "}"
    ]
   }

--- a/JointMeasurements/JointMeasurements.sln
+++ b/JointMeasurements/JointMeasurements.sln
@@ -3,7 +3,9 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.27130.2036
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "JointMeasurements", "JointMeasurements.csproj", "{F7A0175F-4217-4343-8A3C-EA68FAAB6B7B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "JointMeasurements", "JointMeasurements.csproj", "{F7A0175F-4217-4343-8A3C-EA68FAAB6B7B}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Common", "..\utilities\Common\Common.csproj", "{F8640A84-E48D-4C12-BB11-94E709003CE9}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -15,6 +17,10 @@ Global
 		{F7A0175F-4217-4343-8A3C-EA68FAAB6B7B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F7A0175F-4217-4343-8A3C-EA68FAAB6B7B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F7A0175F-4217-4343-8A3C-EA68FAAB6B7B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F8640A84-E48D-4C12-BB11-94E709003CE9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F8640A84-E48D-4C12-BB11-94E709003CE9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F8640A84-E48D-4C12-BB11-94E709003CE9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F8640A84-E48D-4C12-BB11-94E709003CE9}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/JointMeasurements/Tasks.qs
+++ b/JointMeasurements/Tasks.qs
@@ -107,13 +107,8 @@ namespace Quantum.Kata.JointMeasurements {
     // Goal:  Change the two-qubit state to α|00⟩ + β|01⟩ + δ|10⟩ + γ|11⟩ using only single-qubit gates and joint measurements.
     //        Do not use two-qubit gates.
     operation ControlledX_General (qs : Qubit[]) : Unit {
-        
-        body (...) {
-            // Hint: You can use an extra qubit to perform this operation.
-            // ...
-        }
-        
-        adjoint self;
+        // Hint: You can use an extra qubit to perform this operation.
+        // ...
     }
     
 }

--- a/JointMeasurements/TestSuiteRunner.cs
+++ b/JointMeasurements/TestSuiteRunner.cs
@@ -8,9 +8,10 @@
 //////////////////////////////////////////////////////////////////////
 
 using Microsoft.Quantum.Simulation.XUnit;
-using Microsoft.Quantum.Simulation.Simulators;
 using Xunit.Abstractions;
 using System.Diagnostics;
+
+using Microsoft.Quantum.Katas;
 
 namespace Quantum.Kata.JointMeasurements
 {
@@ -30,7 +31,7 @@ namespace Quantum.Kata.JointMeasurements
         [OperationDriver(TestNamespace = "Quantum.Kata.JointMeasurements")]
         public void TestTarget(TestOperation op)
         {
-            using (var sim = new QuantumSimulator())
+            using (var sim = new CounterSimulator())
             {
                 // OnLog defines action(s) performed when Q# test calls function Message
                 sim.OnLog += (msg) => { output.WriteLine(msg); };


### PR DESCRIPTION
This is the second part of the fix for #74.