### PR TITLE
Add alternate reference implementation to Measurements, problem 1.9

### DIFF
--- a/Measurements/ReferenceImplementation.qs
+++ b/Measurements/ReferenceImplementation.qs
@@ -194,10 +194,10 @@ namespace Quantum.Kata.Measurements {
     // Alternate reference implementation for task 1.9
     // Slightly more expensive, but uses built-in functions
     operation SuperpositionMeasurement_Alternate (qs : Qubit[], bits1 : Bool[][], bits2 : Bool[][]) : Int {
-        // measure all qubits and, treating the result as a number, check membership in bit arrays
+        // measure all qubits and, treating the result as an integer, check whether it can be found in one of the bit arrays
         let measuredState = ResultArrayAsInt(MultiM(qs));
         for (s in bits1) {
-            if (BoolArrayAsInt(s)==measuredState) {
+            if (BoolArrayAsInt(s) == measuredState) {
                 return 0;
             }
         }

--- a/Measurements/ReferenceImplementation.qs
+++ b/Measurements/ReferenceImplementation.qs
@@ -191,6 +191,20 @@ namespace Quantum.Kata.Measurements {
     }
 
 
+    // Alternate reference implementation for task 1.9
+    // Slightly more expensive, but uses built-in functions
+    operation SuperpositionMeasurement_Alternate (qs : Qubit[], bits1 : Bool[][], bits2 : Bool[][]) : Int {
+        // measure all qubits and, treating the result as a number, check membership in bit arrays
+        let measuredState = ResultArrayAsInt(MultiM(qs));
+        for (s in bits1) {
+            if (BoolArrayAsInt(s)==measuredState) {
+                return 0;
+            }
+        }
+        return 1;
+    }
+
+
     // Task 1.10. |0...0⟩ state or W state ?
     // Input: N qubits (stored in an array) which are guaranteed to be
     //        either in |0...0⟩ state


### PR DESCRIPTION
I wrote an alternate reference implementation for `Measurements` problem `1.9`. At slightly higher computational cost it is slightly more readable by treating boolean arrays as numbers.