### PR TITLE
Add alternate reference implementation to Measurements task 1.10

### DIFF
--- a/Measurements/ReferenceImplementation.qs
+++ b/Measurements/ReferenceImplementation.qs
@@ -216,6 +216,13 @@ namespace Quantum.Kata.Measurements {
     }
 
 
+    // Alternate reference implementation for task 1.10
+    operation AllZerosOrWState_Alternate (qs : Qubit[]) : Int {
+        // if we get 0 then the state is |0...0⟩
+        return ResultArrayAsInt(MultiM(qs)) == 0 ? 0 | 1;
+    }
+
+
     // Task 1.11. GHZ state or W state ?
     // Input: N >= 2 qubits (stored in an array) which are guaranteed to be
     //        either in GHZ state (https://en.wikipedia.org/wiki/Greenberger%E2%80%93Horne%E2%80%93Zeilinger_state)

--- a/Measurements/ReferenceImplementation.qs
+++ b/Measurements/ReferenceImplementation.qs
@@ -218,7 +218,8 @@ namespace Quantum.Kata.Measurements {
 
     // Alternate reference implementation for task 1.10
     operation AllZerosOrWState_Alternate (qs : Qubit[]) : Int {
-        // if we get 0 then the state is |0...0⟩
+        // measure all qubits and convert the result into an integer;
+        // if we get 0 then the state is |0...0⟩, any non-0 integer indicates W state
         return ResultArrayAsInt(MultiM(qs)) == 0 ? 0 | 1;
     }
 


### PR DESCRIPTION
I wrote an alternate reference implementation for Measurements problem 1.10. Using the built-in function `ResultArrayAsInt` I'm able to determine if the qubit register was in the `|0...0⟩` based on whether I get a zero.