### PR TITLE
Add alternate reference implementation to Measurements task 1.11

### DIFF
--- a/Measurements/ReferenceImplementation.qs
+++ b/Measurements/ReferenceImplementation.qs
@@ -243,6 +243,13 @@ namespace Quantum.Kata.Measurements {
     }
 
 
+    // Alternate reference implementation for task 1.11
+    operation GHZOrWState_Alternate (qs : Qubit[]) : Int {
+        let m = ResultArrayAsInt(MultiM(qs));
+        return (m == 0 or m == (1 <<< Length(qs))-1) ? 0 | 1;
+    }
+
+
     // Task 1.12. Distinguish four Bell states
     // Input: two qubits (stored in an array) which are guaranteed to be in one of the four Bell states:
     //         |Φ⁺⟩ = (|00⟩ + |11⟩) / sqrt(2)

--- a/Measurements/ReferenceImplementation.qs
+++ b/Measurements/ReferenceImplementation.qs
@@ -245,6 +245,8 @@ namespace Quantum.Kata.Measurements {
 
     // Alternate reference implementation for task 1.11
     operation GHZOrWState_Alternate (qs : Qubit[]) : Int {
+        // measure all qubits and convert the measurement results into an integer;
+        // measuring GHZ state will produce either a 0...0 result or a 1...1 result, which correspond to integers 0 and 2ᴺ-1, respectively
         let m = ResultArrayAsInt(MultiM(qs));
         return (m == 0 or m == (1 <<< Length(qs))-1) ? 0 | 1;
     }


### PR DESCRIPTION
I'm using the observation that any measurement of GHZ state will either yield `0` or `2^n-1`.