### PR TITLE
Set log level in notebooks validation based on System.Debug variable

### DIFF
--- a/scripts/validate-notebooks.ps1
+++ b/scripts/validate-notebooks.ps1
@@ -50,7 +50,12 @@ function Validate {
 
     #  convert %kata to %check_kata. run Jupyter nbconvert to execute the kata.
     (Get-Content $Notebook -Raw) | ForEach-Object { $_.replace('%kata', '%check_kata') } | Set-Content $CheckNotebook -NoNewline
-    jupyter nbconvert $CheckNotebook --execute  --ExecutePreprocessor.timeout=120 --log-level=DEBUG
+
+    if ($env:SYSTEM_DEBUG -eq "true") {
+        jupyter nbconvert $CheckNotebook --execute  --ExecutePreprocessor.timeout=120 --log-level=DEBUG
+    } else {
+        jupyter nbconvert $CheckNotebook --execute  --ExecutePreprocessor.timeout=120
+    } 
 
     # if jupyter returns an error code, report that this notebook is invalid:
     if ($LastExitCode -ne 0) {


### PR DESCRIPTION
This way by default it runs with normal log level, eliminating the transient timeout we've been seeing, and if we need to investigate some failure closer, we can set log level from Azure Pipelines build queuing interface.