### PR TITLE
Minor fixes to the 'Measurements' kata.

### DIFF
--- a/Measurements/Measurements.ipynb
+++ b/Measurements/Measurements.ipynb
@@ -285,6 +285,13 @@
     "An array of bit strings `[b₁, ..., bₘ]` defines a state that is an equal superposition of all basis states defined by bit strings $b_1, ..., b_m$.  \n",
     "For example, an array of bit strings `[[false, true, false], [false, true, true]]` defines a superposition state $\\frac{1}{\\sqrt2}\\big(|010\\rangle + |011\\rangle\\big)$.\n",
     "\n",
+    "You are guaranteed that there exists an index of a qubit Q for which: \n",
+    " - all the bit strings in the first array have the same value in this position (all `bits1[j][Q]` are the same),\n",
+    " - all the bit strings in the second array have the same value in this position (all `bits2[j][Q]` are the same),\n",
+    " - these values are different for the first and the second arrays.\n",
+    "\n",
+    "> For example, for arrays `[[false, true, false], [false, true, true]]` and `[[true, false, true], [false, false, true]]` return 0 corresponds to state $\\frac{1}{\\sqrt2}\\big(|010\\rangle + |011\\rangle\\big)$, return 1 - to state $\\frac{1}{\\sqrt2}\\big(|101\\rangle + |001\\rangle\\big)$, and you can distinguish these states perfectly by measuring the second qubit.\n",
+    "\n",
     "**Output:** \n",
     "\n",
     "* 0 if qubits were in the superposition state described by the first array,\n",
@@ -292,13 +299,7 @@
     "\n",
     "The state of the qubits at the end of the operation does not matter.\n",
     "\n",
-    "You are allowed to use exactly one measurement.  \n",
-    "You are guaranteed that there exists an index of a qubit Q for which: \n",
-    " - all the bit strings in the first array have the same value in this position (all `bits1[j][Q]` are the same),\n",
-    " - all the bit strings in the second array have the same value in this position (all `bits2[j][Q]` are the same),\n",
-    " - these values are different for the first and the second arrays.\n",
-    "\n",
-    "> For example, for arrays `[[false, true, false], [false, true, true]]` and `[[true, false, true], [false, false, true]]` return 0 corresponds to state $\\frac{1}{\\sqrt2}\\big(|010\\rangle + |011\\rangle\\big)$, return 1 - to state $\\frac{1}{\\sqrt2}\\big(|101\\rangle + |001\\rangle\\big)$, and you can distinguish these states perfectly by measuring the second qubit."
+    "You are allowed to use exactly one measurement.  \n"
    ]
   },
   {
@@ -327,20 +328,18 @@
     "The arrays describe the superposition states in the same way as in the previous task,\n",
     "i.e. they have dimensions $M_1 \\times N$ and $M_2 \\times N$ respectively, $N$ being the number of qubits.\n",
     "\n",
-    "**Output:** \n",
+    "The only constraint on the bit strings is that **all bit strings in the two arrays are distinct**. \n",
     "\n",
-    "* 0 if the qubits are measured to be composed of the basis state described by the first array,\n",
-    "* 1 if the qubits are measured to be composed of the basis state described by the second array.\n",
+    "> Example:  for bit strings `[[false, true, false], [false, false, true]]` and `[[true, true, true], [false, true, true]]` return 0 corresponds to state $\\frac{1}{\\sqrt2}\\big(|010\\rangle + |001\\rangle\\big)$, return 1 to state $\\frac{1}{\\sqrt2}\\big(|111\\rangle + |011\\rangle\\big)$.\n",
+    "\n",
+    "**Output:** \n",
     "\n",
     "* 0 if qubits were in the superposition state described by the first array,\n",
     "* 1 if they were in the superposition state described by the second array.\n",
     "\n",
     "The state of the qubits at the end of the operation does not matter.\n",
     "\n",
-    "You can use as many measurements as you wish.  \n",
-    "The only constraint on the bit strings is that all bit strings in the two arrays are distinct. \n",
-    "\n",
-    "> Example:  for bit strings `[[false, true, false], [false, false, true]]` and `[[true, true, true], [false, true, true]]` return 0 corresponds to state $\\frac{1}{\\sqrt2}\\big(|010\\rangle + |001\\rangle\\big)$, return 1 - to state $\\frac{1}{\\sqrt2}\\big(|111\\rangle + |011\\rangle\\big)$,"
+    "You can use as many measurements as you wish.  \n"
    ]
   },
   {


### PR DESCRIPTION
This PR fixes the following minor details in the "Measurement" kata:
- task 1.8 - move the "You are guaranteed..." part and the example up to input description (before output), otherwise it's hard to notice
- task 1.9 - fix "output" description - delete the first two lines ("0 if the qubits are measured to be composed of the basis state described by the first array, 1 if the qubits are measured to be composed of the basis state described by the second array."), since they duplicate the second two lines
- task 1.9 - move line "The only constraint on the bit strings is that all bit strings in the two arrays are distinct." up to input description
- task 1.9 - make the line "all bit strings are distinct" more prominent (bold)