### PR TITLE
Fix broken link in DeutschJoszaAlgorithm README

### DIFF
--- a/tutorials/ExploringDeutschJozsaAlgorithm/README.md
+++ b/tutorials/ExploringDeutschJozsaAlgorithm/README.md
@@ -2,7 +2,7 @@
 
 This folder contains a Notebook tutorial on the Deutsch-Jozsa algorithm - a quantum computing algorithm that has no practical use, but is famous for being one of the first examples of a quantum algorithm that is exponentially faster than any deterministic classical algorithm.
 
-You can run the tutorial online [here](https://mybinder.org/v2/gh/Microsoft/QuantumKatas/master?filepath=tutorials/DeutschJozsaAlgorithm%2FDeutschJozsaAlgorithmTutorial.ipynb). Alternatively, you can install Jupyter and Q# on your machine, as described [here](https://docs.microsoft.com/quantum/install-guide/jupyter), and run the tutorial locally by navigating to this folder and starting the notebook from command line using the following command: 
+You can run the tutorial online [here](https://mybinder.org/v2/gh/Microsoft/QuantumKatas/master?filepath=tutorials/ExploringDeutschJozsaAlgorithm%2FDeutschJozsaAlgorithmTutorial.ipynb). Alternatively, you can install Jupyter and Q# on your machine, as described [here](https://docs.microsoft.com/quantum/install-guide/jupyter), and run the tutorial locally by navigating to this folder and starting the notebook from command line using the following command: 
 
     jupyter notebook DeutschJozsaAlgorithmTutorial.ipynb
 

--- a/tutorials/MultiQubitGates/README.md
+++ b/tutorials/MultiQubitGates/README.md
@@ -1,0 +1,8 @@
+# Welcome!
+
+This tutorial discusses applying quantum gates to multi-qubit systems.
+
+You can run the tutorial online [here](https://mybinder.org/v2/gh/Microsoft/QuantumKatas/master?filepath=tutorials/MultiQubitGates/MultiQubitGates.ipynb).
+Alternatively, you can install Jupyter and Q# on your machine, as described [here](https://docs.microsoft.com/quantum/install-guide#develop-with-jupyter-notebooks), and run the tutorial locally by navigating to this folder and starting the notebook from the command line using the following command:
+
+    jupyter notebook MultiQubitGates.ipynb


### PR DESCRIPTION
Current link is missing a word. Gives a 404 after a few seconds :)