### PR TITLE
ENABLE_KATAS build environment variable

### DIFF
--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -25,7 +25,7 @@ function Build-One {
 # Microsoft.Quantum.Katas.sln should always be built:
 Build-One '..\utilities\Microsoft.Quantum.Katas\Microsoft.Quantum.Katas.sln'
 
-# All katas projects might be disable with the ENABLE_KATAS 
+# Building all katas projects can be disabled with the ENABLE_KATAS 
 if ($Env:ENABLE_KATAS -ne "false") {
     Get-ChildItem (Join-Path $PSScriptRoot '..') -Recurse -Include '*.sln' -Exclude 'Microsoft.Quantum.Katas.sln' `
         | ForEach-Object { Build-One $_.FullName }

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -22,8 +22,16 @@ function Build-One {
     $script:all_ok = ($LastExitCode -eq 0) -and $script:all_ok
 }
 
-Get-ChildItem (Join-Path $PSScriptRoot '..') -Recurse -Include '*.sln' `
-    | ForEach-Object { Build-One $_.FullName }
+# Microsoft.Quantum.Katas.sln should always be built:
+Build-One '..\utilities\Microsoft.Quantum.Katas\Microsoft.Quantum.Katas.sln'
+
+# All katas projects might be disable with the ENABLE_KATAS 
+if ($Env:ENABLE_KATAS -ne "false") {
+    Get-ChildItem (Join-Path $PSScriptRoot '..') -Recurse -Include '*.sln' -Exclude 'Microsoft.Quantum.Katas.sln' `
+        | ForEach-Object { Build-One $_.FullName }
+} else {
+    Write-Host "##vso[task.logissue type=warning;]Skipping building Katas solutions. Env:ENABLE_KATAS is '$Env:ENABLE_KATAS'."
+}
 
 if (-not $all_ok) {
     throw "At least one test failed execution. Check the logs."

--- a/scripts/test.ps1
+++ b/scripts/test.ps1
@@ -7,4 +7,9 @@ $ErrorActionPreference = 'Stop'
 
 & "$PSScriptRoot/validate-unicode.ps1"
 
-& "$PSScriptRoot/validate-notebooks.ps1"
+# All katas projects might be disable with the ENABLE_KATAS 
+if ($Env:ENABLE_KATAS -ne "false") {
+  & "$PSScriptRoot/validate-notebooks.ps1"
+} else {
+  Write-Host "##vso[task.logissue type=warning;]Skipping testing Katas notebooks. Env:ENABLE_KATAS is '$Env:ENABLE_KATAS'."
+}

--- a/scripts/test.ps1
+++ b/scripts/test.ps1
@@ -7,7 +7,7 @@ $ErrorActionPreference = 'Stop'
 
 & "$PSScriptRoot/validate-unicode.ps1"
 
-# All katas projects might be disable with the ENABLE_KATAS 
+# Validating all katas projects can be disables with the ENABLE_KATAS 
 if ($Env:ENABLE_KATAS -ne "false") {
   & "$PSScriptRoot/validate-notebooks.ps1"
 } else {


### PR DESCRIPTION
When this variable is set, we will only build the Microsoft.Quantum.Katas nuget package but we will not build individual Katas or their notebooks.
This to help improve build performance when doing end-to-end QDK builds.