### PR TITLE
Fixes to match microsoft/QuantumLibraries#203.

### DIFF
--- a/JointMeasurements/ReferenceImplementation.qs
+++ b/JointMeasurements/ReferenceImplementation.qs
@@ -9,7 +9,7 @@
 //////////////////////////////////////////////////////////////////////
 
 namespace Quantum.Kata.JointMeasurements {    
-    open Microsoft.Quantum.Characterization as Characterization;
+    open Microsoft.Quantum.Characterization;
     open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Measurement;
     
@@ -41,7 +41,7 @@ namespace Quantum.Kata.JointMeasurements {
         // Since the number of qubits in qs is even, the parity of both |0..0⟩ and |1..1⟩ basis states is 0,
         // so both of them belong to the +1 eigenspace of operator Z ⊗ Z ⊗ ... ⊗ Z. 
         // All basis vectors in W state have parity 1 and belong to the -1 eigenspace of this operator.
-        return Characterization.MeasureAllZ(qs) == Zero ? 0 | 1;
+        return MeasureAllZ(qs) == Zero ? 0 | 1;
     }
     
     
@@ -74,10 +74,10 @@ namespace Quantum.Kata.JointMeasurements {
                 let c = qs[0];
                 let t = qs[1];
                 H(a);
-                let p1 = Characterization.MeasureAllZ([c, a]);
+                let p1 = MeasureAllZ([c, a]);
                 H(a);
                 H(t);
-                let p2 = Characterization.MeasureAllZ([a, t]);
+                let p2 = MeasureAllZ([a, t]);
                 H(a);
                 H(t);
                 let m = MResetZ(a);

--- a/JointMeasurements/ReferenceImplementation.qs
+++ b/JointMeasurements/ReferenceImplementation.qs
@@ -41,7 +41,7 @@ namespace Quantum.Kata.JointMeasurements {
         // Since the number of qubits in qs is even, the parity of both |0..0⟩ and |1..1⟩ basis states is 0,
         // so both of them belong to the +1 eigenspace of operator Z ⊗ Z ⊗ ... ⊗ Z. 
         // All basis vectors in W state have parity 1 and belong to the -1 eigenspace of this operator.
-        return MeasureAllZ(qs) == Zero ? 0 | 1;
+        return Characterization.MeasureAllZ(qs) == Zero ? 0 | 1;
     }
     
     
@@ -74,10 +74,10 @@ namespace Quantum.Kata.JointMeasurements {
                 let c = qs[0];
                 let t = qs[1];
                 H(a);
-                let p1 = MeasureAllZ([c, a]);
+                let p1 = Characterization.MeasureAllZ([c, a]);
                 H(a);
                 H(t);
-                let p2 = MeasureAllZ([a, t]);
+                let p2 = Characterization.MeasureAllZ([a, t]);
                 H(a);
                 H(t);
                 let m = MResetZ(a);

--- a/JointMeasurements/ReferenceImplementation.qs
+++ b/JointMeasurements/ReferenceImplementation.qs
@@ -9,7 +9,7 @@
 //////////////////////////////////////////////////////////////////////
 
 namespace Quantum.Kata.JointMeasurements {    
-    open Microsoft.Quantum.Characterization;
+    open Microsoft.Quantum.Characterization as Characterization;
     open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Measurement;
     

--- a/JointMeasurements/ReferenceImplementation.qs
+++ b/JointMeasurements/ReferenceImplementation.qs
@@ -8,9 +8,8 @@
 // but feel free to look up the solution if you get stuck.
 //////////////////////////////////////////////////////////////////////
 
-namespace Quantum.Kata.JointMeasurements {
-    
-    open Microsoft.Quantum.Characterization;
+namespace Quantum.Kata.JointMeasurements {    
+    open Microsoft.Quantum.Characterization as Characterization;
     open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Measurement;
     
@@ -42,7 +41,7 @@ namespace Quantum.Kata.JointMeasurements {
         // Since the number of qubits in qs is even, the parity of both |0..0⟩ and |1..1⟩ basis states is 0,
         // so both of them belong to the +1 eigenspace of operator Z ⊗ Z ⊗ ... ⊗ Z. 
         // All basis vectors in W state have parity 1 and belong to the -1 eigenspace of this operator.
-        return MeasureAllZ(qs) == Zero ? 0 | 1;
+        return Characterization.MeasureAllZ(qs) == Zero ? 0 | 1;
     }
     
     
@@ -75,10 +74,10 @@ namespace Quantum.Kata.JointMeasurements {
                 let c = qs[0];
                 let t = qs[1];
                 H(a);
-                let p1 = MeasureAllZ([c, a]);
+                let p1 = Characterization.MeasureAllZ([c, a]);
                 H(a);
                 H(t);
-                let p2 = MeasureAllZ([a, t]);
+                let p2 = Characterization.MeasureAllZ([a, t]);
                 H(a);
                 H(t);
                 let m = MResetZ(a);

--- a/JointMeasurements/Tests.qs
+++ b/JointMeasurements/Tests.qs
@@ -7,9 +7,8 @@
 // The tasks themselves can be found in Tasks.qs file.
 //////////////////////////////////////////////////////////////////////
 
-namespace Quantum.Kata.JointMeasurements {
-    
-    open Microsoft.Quantum.Characterization;
+namespace Quantum.Kata.JointMeasurements {    
+    open Microsoft.Quantum.Characterization as Characterization;
     open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Canon;
     open Microsoft.Quantum.Diagnostics;
@@ -164,7 +163,7 @@ namespace Quantum.Kata.JointMeasurements {
     // for the purposes of the last two tasks: prohibiting all multi-qubit operations,
     // except the two that are allowed to be used for solving this task
     operation GetMultiQubitNonMeasurementOpCount () : Int {
-        return GetMultiQubitOpCount() - GetOracleCallsCount(Measure) - GetOracleCallsCount(MeasureAllZ);
+        return GetMultiQubitOpCount() - GetOracleCallsCount(Measure) - GetOracleCallsCount(Characterization.MeasureAllZ);
     }
     
     


### PR DESCRIPTION
This PR works around a namespace collision for the deprecation shim in microsoft/quantumlibraries#203, allowing for that PR to move Microsoft.Quantum.Characterization.MeasureAllZ to Microsoft.Quantum.Measurement.MeasureAllZ, as per @tcNickolas's suggestion during API reviews.