### PR TITLE
Revert "Updating netcoreapp3.0 to netcoreapp3.1"

### DIFF
--- a/BasicGates/BasicGates.csproj
+++ b/BasicGates/BasicGates.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <IsPackable>false</IsPackable>
     <RootNamespace>Quantum.Kata.BasicGates</RootNamespace>

--- a/CHSHGame/CHSHGame.csproj
+++ b/CHSHGame/CHSHGame.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <IsPackable>false</IsPackable>
     <RootNamespace>Quantum.Kata.CHSHGame</RootNamespace>

--- a/DeutschJozsaAlgorithm/DeutschJozsaAlgorithm.csproj
+++ b/DeutschJozsaAlgorithm/DeutschJozsaAlgorithm.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <RootNamespace>Quantum.Kata.DeutschJozsaAlgorithm</RootNamespace>
   </PropertyGroup>

--- a/GHZGame/GHZGame.csproj
+++ b/GHZGame/GHZGame.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <IsPackable>false</IsPackable>
     <RootNamespace>Quantum.Kata.GHZGame</RootNamespace>

--- a/GraphColoring/GraphColoring.csproj
+++ b/GraphColoring/GraphColoring.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <IsPackable>false</IsPackable>
     <RootNamespace>Quantum.Kata.GraphColoring</RootNamespace>

--- a/GroversAlgorithm/GroversAlgorithm.csproj
+++ b/GroversAlgorithm/GroversAlgorithm.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <IsPackable>false</IsPackable>
     <RootNamespace>Quantum.Kata.GroversAlgorithm</RootNamespace>

--- a/JointMeasurements/JointMeasurements.csproj
+++ b/JointMeasurements/JointMeasurements.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <IsPackable>false</IsPackable>
     <RootNamespace>Quantum.Kata.JointMeasurements</RootNamespace>

--- a/KeyDistribution_BB84/KeyDistribution_BB84.csproj
+++ b/KeyDistribution_BB84/KeyDistribution_BB84.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <IsPackable>false</IsPackable>
     <RootNamespace>Quantum.Kata.KeyDistribution</RootNamespace>

--- a/MagicSquareGame/MagicSquareGame.csproj
+++ b/MagicSquareGame/MagicSquareGame.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <IsPackable>false</IsPackable>
     <RootNamespace>Quantum.Kata.MagicSquareGame</RootNamespace>

--- a/Measurements/Measurements.csproj
+++ b/Measurements/Measurements.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <IsPackable>false</IsPackable>
     <RootNamespace>Quantum.Kata.Measurements</RootNamespace>

--- a/PhaseEstimation/PhaseEstimation.csproj
+++ b/PhaseEstimation/PhaseEstimation.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <IsPackable>false</IsPackable>
     <RootNamespace>Quantum.Kata.PhaseEstimation</RootNamespace>

--- a/QEC_BitFlipCode/QEC_BitFlipCode.csproj
+++ b/QEC_BitFlipCode/QEC_BitFlipCode.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <IsPackable>false</IsPackable>
     <RootNamespace>Quantum.Kata.QEC_BitFlipCode</RootNamespace>

--- a/RippleCarryAdder/RippleCarryAdder.csproj
+++ b/RippleCarryAdder/RippleCarryAdder.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <IsPackable>false</IsPackable>
     <RootNamespace>Quantum.Kata.RippleCarryAdder</RootNamespace>

--- a/SimonsAlgorithm/SimonsAlgorithm.csproj
+++ b/SimonsAlgorithm/SimonsAlgorithm.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <IsPackable>false</IsPackable>
     <RootNamespace>Quantum.Kata.SimonsAlgorithm</RootNamespace>

--- a/SolveSATWithGrover/SolveSATWithGrover.csproj
+++ b/SolveSATWithGrover/SolveSATWithGrover.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <IsPackable>false</IsPackable>
     <RootNamespace>Quantum.Kata.GroversAlgorithm</RootNamespace>

--- a/SuperdenseCoding/SuperdenseCoding.csproj
+++ b/SuperdenseCoding/SuperdenseCoding.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <IsPackable>false</IsPackable>
     <RootNamespace>Quantum.Kata.SuperdenseCoding</RootNamespace>

--- a/Superposition/Superposition.csproj
+++ b/Superposition/Superposition.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <IsPackable>false</IsPackable>
     <RootNamespace>Quantum.Kata.Superposition</RootNamespace>

--- a/Teleportation/Teleportation.csproj
+++ b/Teleportation/Teleportation.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <IsPackable>false</IsPackable>
     <RootNamespace>Quantum.Kata.Teleportation</RootNamespace>

--- a/TruthTables/TruthTables.csproj
+++ b/TruthTables/TruthTables.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <IsPackable>false</IsPackable>
     <RootNamespace>Quantum.Kata.TruthTables</RootNamespace>

--- a/UnitaryPatterns/UnitaryPatterns.csproj
+++ b/UnitaryPatterns/UnitaryPatterns.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <IsPackable>false</IsPackable>
     <RootNamespace>Quantum.Kata.UnitaryPatterns</RootNamespace>

--- a/scripts/steps.yml
+++ b/scripts/steps.yml
@@ -3,16 +3,11 @@ steps:
 ##
 # Pre-reqs
 ##
-- task: NuGetToolInstaller@0
-  displayName: 'Use NuGet 5.2.0'
-  inputs:
-    versionSpec: '5.2.0'
-
 - task: UseDotNet@2
-  displayName: 'Use .NET Core SDK 3.1.100'
+  displayName: 'Use .NET Core SDK 3.0.100'
   inputs:
     packageType: sdk
-    version: '3.1.100'
+    version: '3.0.100'
 
 - task: UsePythonVersion@0
   inputs:

--- a/tutorials/ExploringDeutschJozsaAlgorithm/DeutschJozsaAlgorithmTutorial.csproj
+++ b/tutorials/ExploringDeutschJozsaAlgorithm/DeutschJozsaAlgorithmTutorial.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <RootNamespace>Quantum.Kata.DeutschJozsaAlgorithm</RootNamespace>
   </PropertyGroup>

--- a/tutorials/ExploringGroversAlgorithm/ExploringGroversAlgorithmTutorial.csproj
+++ b/tutorials/ExploringGroversAlgorithm/ExploringGroversAlgorithmTutorial.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <RootNamespace>Quantum.Kata.ExploringGroversAlgorithm</RootNamespace>
   </PropertyGroup>

--- a/tutorials/MultiQubitGates/MultiQubitGates.csproj
+++ b/tutorials/MultiQubitGates/MultiQubitGates.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <RootNamespace>Quantum.Kata.MultiQubitGates</RootNamespace>
   </PropertyGroup>

--- a/tutorials/MultiQubitSystems/MultiQubitSystems.csproj
+++ b/tutorials/MultiQubitSystems/MultiQubitSystems.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <RootNamespace>Quantum.Kata.MultiQubitSystems</RootNamespace>
   </PropertyGroup>

--- a/tutorials/SingleQubitGates/SingleQubitGates.csproj
+++ b/tutorials/SingleQubitGates/SingleQubitGates.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <RootNamespace>Quantum.Kata.SingleQubitGates</RootNamespace>
   </PropertyGroup>

--- a/utilities/DumpUnitary/DumpUnitary.csproj
+++ b/utilities/DumpUnitary/DumpUnitary.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>

--- a/utilities/DumpUnitaryTest/DumpUnitaryTest.csproj
+++ b/utilities/DumpUnitaryTest/DumpUnitaryTest.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
Reverts microsoft/QuantumKatas#298

This change introduces build breaks to the Binder image:

    error NETSDK1045: The current .NET SDK does not support targeting .NET Core 3.1.  Either target .NET Core 3.0 or lower, or use a version of the .NET SDK that supports .NET Core 3.1.

We need to investigate the build breaks before doing this change.