### PR TITLE
Updating QDK version to 0.11.2003.3107

### DIFF
--- a/BasicGates/BasicGates.csproj
+++ b/BasicGates/BasicGates.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.10.2002.2610" />
-    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.10.2002.2610" />
-    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.10.2002.2610" />
+    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.11.2003.3107" />
+    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.11.2003.3107" />
+    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.11.2003.3107" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/BasicGates/BasicGates.csproj
+++ b/BasicGates/BasicGates.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <IsPackable>false</IsPackable>
     <RootNamespace>Quantum.Kata.BasicGates</RootNamespace>

--- a/BasicGates/BasicGates.ipynb
+++ b/BasicGates/BasicGates.ipynb
@@ -36,7 +36,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%package Microsoft.Quantum.Katas::0.10.2002.2610"
+    "%package Microsoft.Quantum.Katas::0.11.2003.3107"
    ]
   },
   {

--- a/CHSHGame/CHSHGame.csproj
+++ b/CHSHGame/CHSHGame.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.10.2002.2610" />
-    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.10.2002.2610" />
-    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.10.2002.2610" />
+    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.11.2003.3107" />
+    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.11.2003.3107" />
+    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.11.2003.3107" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/CHSHGame/CHSHGame.csproj
+++ b/CHSHGame/CHSHGame.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <IsPackable>false</IsPackable>
     <RootNamespace>Quantum.Kata.CHSHGame</RootNamespace>

--- a/CHSHGame/CHSHGame.ipynb
+++ b/CHSHGame/CHSHGame.ipynb
@@ -39,7 +39,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%package Microsoft.Quantum.Katas::0.10.2002.2610"
+    "%package Microsoft.Quantum.Katas::0.11.2003.3107"
    ]
   },
   {

--- a/DeutschJozsaAlgorithm/DeutschJozsaAlgorithm.csproj
+++ b/DeutschJozsaAlgorithm/DeutschJozsaAlgorithm.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <RootNamespace>Quantum.Kata.DeutschJozsaAlgorithm</RootNamespace>
   </PropertyGroup>

--- a/DeutschJozsaAlgorithm/DeutschJozsaAlgorithm.csproj
+++ b/DeutschJozsaAlgorithm/DeutschJozsaAlgorithm.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.10.2002.2610" />
-    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.10.2002.2610" />
-    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.10.2002.2610" />
+    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.11.2003.3107" />
+    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.11.2003.3107" />
+    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.11.2003.3107" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/DeutschJozsaAlgorithm/DeutschJozsaAlgorithm.ipynb
+++ b/DeutschJozsaAlgorithm/DeutschJozsaAlgorithm.ipynb
@@ -34,7 +34,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%package Microsoft.Quantum.Katas::0.10.2002.2610"
+    "%package Microsoft.Quantum.Katas::0.11.2003.3107"
    ]
   },
   {

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # We use the iqsharp-base image, as that includes
 # the .NET Core SDK, IQ#, and Jupyter Notebook already
 # installed for us.
-FROM mcr.microsoft.com/quantum/iqsharp-base:0.10.2002.2610
+FROM mcr.microsoft.com/quantum/iqsharp-base:0.11.2003.3107
 
 # Add metadata indicating that this image is used for the katas.
 ENV IQSHARP_HOSTING_ENV=KATAS_DOCKERFILE

--- a/GHZGame/GHZGame.csproj
+++ b/GHZGame/GHZGame.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.10.2002.2610" />
-    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.10.2002.2610" />
-    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.10.2002.2610" />
+    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.11.2003.3107" />
+    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.11.2003.3107" />
+    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.11.2003.3107" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/GHZGame/GHZGame.csproj
+++ b/GHZGame/GHZGame.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <IsPackable>false</IsPackable>
     <RootNamespace>Quantum.Kata.GHZGame</RootNamespace>

--- a/GHZGame/GHZGame.ipynb
+++ b/GHZGame/GHZGame.ipynb
@@ -38,7 +38,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%package Microsoft.Quantum.Katas::0.10.2002.2610"
+    "%package Microsoft.Quantum.Katas::0.11.2003.3107"
    ]
   },
   {

--- a/GraphColoring/GraphColoring.csproj
+++ b/GraphColoring/GraphColoring.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.10.2002.2610" />
-    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.10.2002.2610" />
-    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.10.2002.2610" />
+    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.11.2003.3107" />
+    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.11.2003.3107" />
+    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.11.2003.3107" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/GraphColoring/GraphColoring.csproj
+++ b/GraphColoring/GraphColoring.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <IsPackable>false</IsPackable>
     <RootNamespace>Quantum.Kata.GraphColoring</RootNamespace>

--- a/GraphColoring/GraphColoring.ipynb
+++ b/GraphColoring/GraphColoring.ipynb
@@ -36,7 +36,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%package Microsoft.Quantum.Katas::0.10.2002.2610"
+    "%package Microsoft.Quantum.Katas::0.11.2003.3107"
    ]
   },
   {

--- a/GroversAlgorithm/GroversAlgorithm.csproj
+++ b/GroversAlgorithm/GroversAlgorithm.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.10.2002.2610" />
-    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.10.2002.2610" />
-    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.10.2002.2610" />
+    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.11.2003.3107" />
+    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.11.2003.3107" />
+    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.11.2003.3107" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/GroversAlgorithm/GroversAlgorithm.csproj
+++ b/GroversAlgorithm/GroversAlgorithm.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <IsPackable>false</IsPackable>
     <RootNamespace>Quantum.Kata.GroversAlgorithm</RootNamespace>

--- a/GroversAlgorithm/GroversAlgorithm.ipynb
+++ b/GroversAlgorithm/GroversAlgorithm.ipynb
@@ -47,7 +47,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%package Microsoft.Quantum.Katas::0.10.2002.2610"
+    "%package Microsoft.Quantum.Katas::0.11.2003.3107"
    ]
   },
   {

--- a/JointMeasurements/JointMeasurements.csproj
+++ b/JointMeasurements/JointMeasurements.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.10.2002.2610" />
-    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.10.2002.2610" />
-    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.10.2002.2610" />
+    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.11.2003.3107" />
+    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.11.2003.3107" />
+    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.11.2003.3107" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/JointMeasurements/JointMeasurements.csproj
+++ b/JointMeasurements/JointMeasurements.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <IsPackable>false</IsPackable>
     <RootNamespace>Quantum.Kata.JointMeasurements</RootNamespace>

--- a/JointMeasurements/JointMeasurements.ipynb
+++ b/JointMeasurements/JointMeasurements.ipynb
@@ -30,7 +30,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%package Microsoft.Quantum.Katas::0.10.2002.2610"
+    "%package Microsoft.Quantum.Katas::0.11.2003.3107"
    ]
   },
   {

--- a/KeyDistribution_BB84/KeyDistribution_BB84.csproj
+++ b/KeyDistribution_BB84/KeyDistribution_BB84.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.10.2002.2610" />
-    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.10.2002.2610" />
-    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.10.2002.2610" />
+    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.11.2003.3107" />
+    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.11.2003.3107" />
+    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.11.2003.3107" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/KeyDistribution_BB84/KeyDistribution_BB84.csproj
+++ b/KeyDistribution_BB84/KeyDistribution_BB84.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <IsPackable>false</IsPackable>
     <RootNamespace>Quantum.Kata.KeyDistribution</RootNamespace>

--- a/KeyDistribution_BB84/KeyDistribution_BB84.ipynb
+++ b/KeyDistribution_BB84/KeyDistribution_BB84.ipynb
@@ -30,7 +30,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%package Microsoft.Quantum.Katas::0.10.2002.2610"
+    "%package Microsoft.Quantum.Katas::0.11.2003.3107"
    ]
   },
   {

--- a/MagicSquareGame/MagicSquareGame.csproj
+++ b/MagicSquareGame/MagicSquareGame.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.10.2002.2610" />
-    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.10.2002.2610" />
-    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.10.2002.2610" />
+    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.11.2003.3107" />
+    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.11.2003.3107" />
+    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.11.2003.3107" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/MagicSquareGame/MagicSquareGame.csproj
+++ b/MagicSquareGame/MagicSquareGame.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <IsPackable>false</IsPackable>
     <RootNamespace>Quantum.Kata.MagicSquareGame</RootNamespace>

--- a/MagicSquareGame/MagicSquareGame.ipynb
+++ b/MagicSquareGame/MagicSquareGame.ipynb
@@ -45,7 +45,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%package Microsoft.Quantum.Katas::0.10.2002.2610"
+    "%package Microsoft.Quantum.Katas::0.11.2003.3107"
    ]
   },
   {

--- a/Measurements/Measurements.csproj
+++ b/Measurements/Measurements.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.10.2002.2610" />
-    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.10.2002.2610" />
-    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.10.2002.2610" />
+    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.11.2003.3107" />
+    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.11.2003.3107" />
+    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.11.2003.3107" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/Measurements/Measurements.csproj
+++ b/Measurements/Measurements.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <IsPackable>false</IsPackable>
     <RootNamespace>Quantum.Kata.Measurements</RootNamespace>

--- a/Measurements/Measurements.ipynb
+++ b/Measurements/Measurements.ipynb
@@ -32,7 +32,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%package Microsoft.Quantum.Katas::0.10.2002.2610"
+    "%package Microsoft.Quantum.Katas::0.11.2003.3107"
    ]
   },
   {

--- a/PhaseEstimation/PhaseEstimation.csproj
+++ b/PhaseEstimation/PhaseEstimation.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.10.2002.2610" />
-    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.10.2002.2610" />
-    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.10.2002.2610" />
+    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.11.2003.3107" />
+    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.11.2003.3107" />
+    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.11.2003.3107" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/PhaseEstimation/PhaseEstimation.csproj
+++ b/PhaseEstimation/PhaseEstimation.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <IsPackable>false</IsPackable>
     <RootNamespace>Quantum.Kata.PhaseEstimation</RootNamespace>

--- a/PhaseEstimation/PhaseEstimation.ipynb
+++ b/PhaseEstimation/PhaseEstimation.ipynb
@@ -35,7 +35,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%package Microsoft.Quantum.Katas::0.10.2002.2610"
+    "%package Microsoft.Quantum.Katas::0.11.2003.3107"
    ]
   },
   {

--- a/QEC_BitFlipCode/QEC_BitFlipCode.csproj
+++ b/QEC_BitFlipCode/QEC_BitFlipCode.csproj
@@ -10,9 +10,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.10.2002.2610" />
-    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.10.2002.2610" />
-    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.10.2002.2610" />
+    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.11.2003.3107" />
+    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.11.2003.3107" />
+    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.11.2003.3107" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/QEC_BitFlipCode/QEC_BitFlipCode.csproj
+++ b/QEC_BitFlipCode/QEC_BitFlipCode.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <IsPackable>false</IsPackable>
     <RootNamespace>Quantum.Kata.QEC_BitFlipCode</RootNamespace>

--- a/QEC_BitFlipCode/QEC_BitFlipCode.ipynb
+++ b/QEC_BitFlipCode/QEC_BitFlipCode.ipynb
@@ -28,7 +28,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%package Microsoft.Quantum.Katas::0.10.2002.2610"
+    "%package Microsoft.Quantum.Katas::0.11.2003.3107"
    ]
   },
   {

--- a/RippleCarryAdder/RippleCarryAdder.csproj
+++ b/RippleCarryAdder/RippleCarryAdder.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <IsPackable>false</IsPackable>
     <RootNamespace>Quantum.Kata.RippleCarryAdder</RootNamespace>

--- a/RippleCarryAdder/RippleCarryAdder.csproj
+++ b/RippleCarryAdder/RippleCarryAdder.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.10.2002.2610" />
-    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.10.2002.2610" />
-    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.10.2002.2610" />
+    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.11.2003.3107" />
+    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.11.2003.3107" />
+    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.11.2003.3107" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/RippleCarryAdder/RippleCarryAdder.ipynb
+++ b/RippleCarryAdder/RippleCarryAdder.ipynb
@@ -38,7 +38,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%package Microsoft.Quantum.Katas::0.10.2002.2610"
+    "%package Microsoft.Quantum.Katas::0.11.2003.3107"
    ]
   },
   {

--- a/SimonsAlgorithm/SimonsAlgorithm.csproj
+++ b/SimonsAlgorithm/SimonsAlgorithm.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.10.2002.2610" />
-    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.10.2002.2610" />
-    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.10.2002.2610" />
+    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.11.2003.3107" />
+    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.11.2003.3107" />
+    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.11.2003.3107" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/SimonsAlgorithm/SimonsAlgorithm.csproj
+++ b/SimonsAlgorithm/SimonsAlgorithm.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <IsPackable>false</IsPackable>
     <RootNamespace>Quantum.Kata.SimonsAlgorithm</RootNamespace>

--- a/SolveSATWithGrover/SolveSATWithGrover.csproj
+++ b/SolveSATWithGrover/SolveSATWithGrover.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.10.2002.2610" />
-    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.10.2002.2610" />
-    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.10.2002.2610" />
+    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.11.2003.3107" />
+    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.11.2003.3107" />
+    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.11.2003.3107" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/SolveSATWithGrover/SolveSATWithGrover.csproj
+++ b/SolveSATWithGrover/SolveSATWithGrover.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <IsPackable>false</IsPackable>
     <RootNamespace>Quantum.Kata.GroversAlgorithm</RootNamespace>

--- a/SolveSATWithGrover/SolveSATWithGrover.ipynb
+++ b/SolveSATWithGrover/SolveSATWithGrover.ipynb
@@ -31,7 +31,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%package Microsoft.Quantum.Katas::0.10.2002.2610"
+    "%package Microsoft.Quantum.Katas::0.11.2003.3107"
    ]
   },
   {

--- a/SuperdenseCoding/SuperdenseCoding.csproj
+++ b/SuperdenseCoding/SuperdenseCoding.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.10.2002.2610" />
-    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.10.2002.2610" />
-    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.10.2002.2610" />
+    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.11.2003.3107" />
+    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.11.2003.3107" />
+    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.11.2003.3107" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/SuperdenseCoding/SuperdenseCoding.csproj
+++ b/SuperdenseCoding/SuperdenseCoding.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <IsPackable>false</IsPackable>
     <RootNamespace>Quantum.Kata.SuperdenseCoding</RootNamespace>

--- a/SuperdenseCoding/SuperdenseCoding.ipynb
+++ b/SuperdenseCoding/SuperdenseCoding.ipynb
@@ -37,7 +37,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%package Microsoft.Quantum.Katas::0.10.2002.2610"
+    "%package Microsoft.Quantum.Katas::0.11.2003.3107"
    ]
   },
   {

--- a/Superposition/Superposition.csproj
+++ b/Superposition/Superposition.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.10.2002.2610" />
-    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.10.2002.2610" />
-    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.10.2002.2610" />
+    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.11.2003.3107" />
+    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.11.2003.3107" />
+    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.11.2003.3107" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/Superposition/Superposition.csproj
+++ b/Superposition/Superposition.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <IsPackable>false</IsPackable>
     <RootNamespace>Quantum.Kata.Superposition</RootNamespace>

--- a/Superposition/Superposition.ipynb
+++ b/Superposition/Superposition.ipynb
@@ -35,7 +35,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%package Microsoft.Quantum.Katas::0.10.2002.2610"
+    "%package Microsoft.Quantum.Katas::0.11.2003.3107"
    ]
   },
   {

--- a/Superposition/Workbook_Superposition.ipynb
+++ b/Superposition/Workbook_Superposition.ipynb
@@ -36,7 +36,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%package Microsoft.Quantum.Katas::0.10.2002.2610"
+    "%package Microsoft.Quantum.Katas::0.11.2003.3107"
    ]
   },
   {

--- a/Superposition/Workbook_Superposition_Part2.ipynb
+++ b/Superposition/Workbook_Superposition_Part2.ipynb
@@ -24,7 +24,7 @@
    },
    "outputs": [],
    "source": [
-    "%package Microsoft.Quantum.Katas::0.10.2002.2610"
+    "%package Microsoft.Quantum.Katas::0.11.2003.3107"
    ]
   },
   {

--- a/Teleportation/Teleportation.csproj
+++ b/Teleportation/Teleportation.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.10.2002.2610" />
-    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.10.2002.2610" />
-    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.10.2002.2610" />
+    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.11.2003.3107" />
+    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.11.2003.3107" />
+    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.11.2003.3107" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/Teleportation/Teleportation.csproj
+++ b/Teleportation/Teleportation.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <IsPackable>false</IsPackable>
     <RootNamespace>Quantum.Kata.Teleportation</RootNamespace>

--- a/Teleportation/Teleportation.ipynb
+++ b/Teleportation/Teleportation.ipynb
@@ -28,7 +28,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%package Microsoft.Quantum.Katas::0.10.2002.2610"
+    "%package Microsoft.Quantum.Katas::0.11.2003.3107"
    ]
   },
   {

--- a/TruthTables/TruthTables.csproj
+++ b/TruthTables/TruthTables.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.10.2002.2610" />
-    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.10.2002.2610" />
-    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.10.2002.2610" />
+    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.11.2003.3107" />
+    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.11.2003.3107" />
+    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.11.2003.3107" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/TruthTables/TruthTables.csproj
+++ b/TruthTables/TruthTables.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <IsPackable>false</IsPackable>
     <RootNamespace>Quantum.Kata.TruthTables</RootNamespace>

--- a/TruthTables/TruthTables.ipynb
+++ b/TruthTables/TruthTables.ipynb
@@ -28,7 +28,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%package Microsoft.Quantum.Katas::0.10.2002.2610"
+    "%package Microsoft.Quantum.Katas::0.11.2003.3107"
    ]
   },
   {

--- a/UnitaryPatterns/UnitaryPatterns.csproj
+++ b/UnitaryPatterns/UnitaryPatterns.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.10.2002.2610" />
-    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.10.2002.2610" />
-    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.10.2002.2610" />
+    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.11.2003.3107" />
+    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.11.2003.3107" />
+    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.11.2003.3107" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/UnitaryPatterns/UnitaryPatterns.csproj
+++ b/UnitaryPatterns/UnitaryPatterns.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <IsPackable>false</IsPackable>
     <RootNamespace>Quantum.Kata.UnitaryPatterns</RootNamespace>

--- a/UnitaryPatterns/UnitaryPatterns.ipynb
+++ b/UnitaryPatterns/UnitaryPatterns.ipynb
@@ -46,7 +46,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%package Microsoft.Quantum.Katas::0.10.2002.2610"
+    "%package Microsoft.Quantum.Katas::0.11.2003.3107"
    ]
   },
   {

--- a/scripts/install-iqsharp.ps1
+++ b/scripts/install-iqsharp.ps1
@@ -20,7 +20,7 @@ try {
 if ($install) {
     try {
         Write-Host ("Installing Microsoft.Quantum.IQSharp at $Env:TOOLS_DIR")
-        dotnet tool install Microsoft.Quantum.IQSharp --version 0.10.2002.2610 --tool-path $Env:TOOLS_DIR
+        dotnet tool install Microsoft.Quantum.IQSharp --version 0.11.2003.3107 --tool-path $Env:TOOLS_DIR
 
         $path = (Get-Item "$Env:TOOLS_DIR\dotnet-iqsharp*").FullName
         & $path install --user --path-to-tool $path

--- a/scripts/steps.yml
+++ b/scripts/steps.yml
@@ -4,10 +4,10 @@ steps:
 # Pre-reqs
 ##
 - task: UseDotNet@2
-  displayName: 'Use .NET Core SDK 3.0.100'
+  displayName: 'Use .NET Core SDK 3.1.201'
   inputs:
     packageType: sdk
-    version: '3.0.100'
+    version: '3.1.201'
 
 - task: UsePythonVersion@0
   inputs:

--- a/scripts/updateQDKVersion.ps1
+++ b/scripts/updateQDKVersion.ps1
@@ -18,7 +18,7 @@ param(
         
     .EXAMPLE
     
-        PS> ./Update-QDKVersion.ps1 -Version 0.10.2002.2610
+        PS> ./Update-QDKVersion.ps1 -Version 0.11.2003.3107
 #>
 
 $katasRoot = Join-Path $PSScriptRoot "\..\"

--- a/tutorials/ExploringDeutschJozsaAlgorithm/DeutschJozsaAlgorithmTutorial.csproj
+++ b/tutorials/ExploringDeutschJozsaAlgorithm/DeutschJozsaAlgorithmTutorial.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <RootNamespace>Quantum.Kata.DeutschJozsaAlgorithm</RootNamespace>
   </PropertyGroup>

--- a/tutorials/ExploringDeutschJozsaAlgorithm/DeutschJozsaAlgorithmTutorial.csproj
+++ b/tutorials/ExploringDeutschJozsaAlgorithm/DeutschJozsaAlgorithmTutorial.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.10.2002.2610" />
-    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.10.2002.2610" />
-    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.10.2002.2610" />
+    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.11.2003.3107" />
+    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.11.2003.3107" />
+    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.11.2003.3107" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/tutorials/ExploringDeutschJozsaAlgorithm/DeutschJozsaAlgorithmTutorial.ipynb
+++ b/tutorials/ExploringDeutschJozsaAlgorithm/DeutschJozsaAlgorithmTutorial.ipynb
@@ -31,7 +31,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%package Microsoft.Quantum.Katas::0.10.2002.2610"
+    "%package Microsoft.Quantum.Katas::0.11.2003.3107"
    ]
   },
   {

--- a/tutorials/ExploringGroversAlgorithm/ExploringGroversAlgorithmTutorial.csproj
+++ b/tutorials/ExploringGroversAlgorithm/ExploringGroversAlgorithmTutorial.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <RootNamespace>Quantum.Kata.ExploringGroversAlgorithm</RootNamespace>
   </PropertyGroup>

--- a/tutorials/ExploringGroversAlgorithm/ExploringGroversAlgorithmTutorial.csproj
+++ b/tutorials/ExploringGroversAlgorithm/ExploringGroversAlgorithmTutorial.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.10.2002.2610" />
-    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.10.2002.2610" />
-    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.10.2002.2610" />
+    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.11.2003.3107" />
+    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.11.2003.3107" />
+    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.11.2003.3107" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/tutorials/MultiQubitGates/MultiQubitGates.csproj
+++ b/tutorials/MultiQubitGates/MultiQubitGates.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <RootNamespace>Quantum.Kata.MultiQubitGates</RootNamespace>
   </PropertyGroup>

--- a/tutorials/MultiQubitGates/MultiQubitGates.csproj
+++ b/tutorials/MultiQubitGates/MultiQubitGates.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.10.2002.2610" />
-    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.10.2002.2610" />
-    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.10.2002.2610" />
+    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.11.2003.3107" />
+    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.11.2003.3107" />
+    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.11.2003.3107" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/tutorials/MultiQubitGates/MultiQubitGates.ipynb
+++ b/tutorials/MultiQubitGates/MultiQubitGates.ipynb
@@ -30,7 +30,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%package Microsoft.Quantum.Katas::0.10.2002.2610"
+    "%package Microsoft.Quantum.Katas::0.11.2003.3107"
    ]
   },
   {

--- a/tutorials/MultiQubitGates/Workbook_MultiQubitGates.ipynb
+++ b/tutorials/MultiQubitGates/Workbook_MultiQubitGates.ipynb
@@ -36,7 +36,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%package Microsoft.Quantum.Katas::0.10.2002.2610"
+    "%package Microsoft.Quantum.Katas::0.11.2003.3107"
    ]
   },
   {

--- a/tutorials/MultiQubitSystems/MultiQubitSystems.csproj
+++ b/tutorials/MultiQubitSystems/MultiQubitSystems.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.10.2002.2610" />
-    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.10.2002.2610" />
-    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.10.2002.2610" />
+    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.11.2003.3107" />
+    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.11.2003.3107" />
+    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.11.2003.3107" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/tutorials/MultiQubitSystems/MultiQubitSystems.csproj
+++ b/tutorials/MultiQubitSystems/MultiQubitSystems.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <RootNamespace>Quantum.Kata.MultiQubitSystems</RootNamespace>
   </PropertyGroup>

--- a/tutorials/MultiQubitSystems/MultiQubitSystems.ipynb
+++ b/tutorials/MultiQubitSystems/MultiQubitSystems.ipynb
@@ -29,7 +29,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%package Microsoft.Quantum.Katas::0.10.2002.2610"
+    "%package Microsoft.Quantum.Katas::0.11.2003.3107"
    ]
   },
   {

--- a/tutorials/SingleQubitGates/SingleQubitGates.csproj
+++ b/tutorials/SingleQubitGates/SingleQubitGates.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <RootNamespace>Quantum.Kata.SingleQubitGates</RootNamespace>
   </PropertyGroup>

--- a/tutorials/SingleQubitGates/SingleQubitGates.csproj
+++ b/tutorials/SingleQubitGates/SingleQubitGates.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.10.2002.2610" />
-    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.10.2002.2610" />
-    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.10.2002.2610" />
+    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.11.2003.3107" />
+    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.11.2003.3107" />
+    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.11.2003.3107" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/tutorials/SingleQubitGates/SingleQubitGates.ipynb
+++ b/tutorials/SingleQubitGates/SingleQubitGates.ipynb
@@ -32,7 +32,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%package Microsoft.Quantum.Katas::0.10.2002.2610"
+    "%package Microsoft.Quantum.Katas::0.11.2003.3107"
    ]
   },
   {

--- a/utilities/Common/Common.csproj
+++ b/utilities/Common/Common.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.10.2002.2610" />
+    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.11.2003.3107" />
   </ItemGroup>
   
 </Project>

--- a/utilities/DumpUnitary/DumpUnitary.csproj
+++ b/utilities/DumpUnitary/DumpUnitary.csproj
@@ -9,7 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.10.2002.2610" />
-    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.10.2002.2610" />
+    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.11.2003.3107" />
+    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.11.2003.3107" />
   </ItemGroup>
 </Project>

--- a/utilities/DumpUnitary/DumpUnitary.csproj
+++ b/utilities/DumpUnitary/DumpUnitary.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>

--- a/utilities/DumpUnitaryTest/DumpUnitaryTest.csproj
+++ b/utilities/DumpUnitaryTest/DumpUnitaryTest.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
Updated and tested the Katas with the latest QDK release (0.11.2003.3107).
I tested it locally (unit tests + manual tests for the Basic Gates and Grover Tutorial) and on Binder with a [custom image](https://mybinder.org/v2/gh/vxfield/QuantumKatasTest/master?filepath=..%2Fnotebooks%2Findex.ipynb%3Forigin%3Dtest).