### PR TITLE
BasicGates katas add clarification about endiannes and qubit order.

### DIFF
--- a/BasicGates/BasicGates.ipynb
+++ b/BasicGates/BasicGates.ipynb
@@ -379,6 +379,8 @@
    "source": [
     "## Part II. Multi-Qubit Gates\n",
     "\n",
+    "The Dirac notations in the following use big-endian format (the most significant bit is stored first), see this [tutorial section](../tutorials/MultiQubitSystems/MultiQubitSystems.ipynb#Endianness) for a refresher on endianness.\n",
+    "\n",
     "### Q# materials\n",
     "\n",
     "* Using controlled and adjoint versions of gates is covered in the Q# documentation on [operation types](https://docs.microsoft.com/quantum/language/type-model#operation-and-function-types)."

--- a/BasicGates/BasicGates.ipynb
+++ b/BasicGates/BasicGates.ipynb
@@ -379,7 +379,7 @@
    "source": [
     "## Part II. Multi-Qubit Gates\n",
     "\n",
-    "The Dirac notations in the following use big-endian format (the most significant bit is stored first), see this [tutorial section](../tutorials/MultiQubitSystems/MultiQubitSystems.ipynb#Endianness) for a refresher on endianness.\n",
+    "In the following tasks the order of qubit states in task description matches the order of qubits in the array (i.e., $|10\\rangle$ state corresponds to `qs[0]` in state $|1\\rangle$ and `qs[1]` in state $|0\\rangle$).\n",
     "\n",
     "### Q# materials\n",
     "\n",

--- a/BasicGates/BasicGates.ipynb
+++ b/BasicGates/BasicGates.ipynb
@@ -379,9 +379,9 @@
    "source": [
     "## Part II. Multi-Qubit Gates\n",
     "\n",
-    "In the following tasks the order of qubit states in task description matches the order of qubits in the array (i.e., $|10\\rangle$ state corresponds to `qs[0]` in state $|1\\rangle$ and `qs[1]` in state $|0\\rangle$).\n",
-    "\n",
-    "Note also that the states shown in test output use little-endian notation (similarly to `DumpMachine`), see this [tutorial section](../tutorials/MultiQubitSystems/MultiQubitSystems.ipynb#Endianness) for a refresher on endianness.\n",
+    "> In the following tasks the order of qubit states in task description matches the order of qubits in the array (i.e., $|10\\rangle$ state corresponds to `qs[0]` in state $|1\\rangle$ and `qs[1]` in state $|0\\rangle$).\n",
+    "> \n",
+    "> Note also that the states shown in test output use little-endian notation (similarly to `DumpMachine`), see this [tutorial section](../tutorials/MultiQubitSystems/MultiQubitSystems.ipynb#Endianness) for a refresher on endianness.\n",
     "\n",
     "### Q# materials\n",
     "\n",
@@ -535,7 +535,7 @@
    "file_extension": ".qs",
    "mimetype": "text/x-qsharp",
    "name": "qsharp",
-   "version": "0.4"
+   "version": "0.10"
   }
  },
  "nbformat": 4,

--- a/BasicGates/BasicGates.ipynb
+++ b/BasicGates/BasicGates.ipynb
@@ -381,6 +381,8 @@
     "\n",
     "In the following tasks the order of qubit states in task description matches the order of qubits in the array (i.e., $|10\\rangle$ state corresponds to `qs[0]` in state $|1\\rangle$ and `qs[1]` in state $|0\\rangle$).\n",
     "\n",
+    "Note also that the states shown in test output use little-endian notation (similarly to `DumpMachine`), see this [tutorial section](../tutorials/MultiQubitSystems/MultiQubitSystems.ipynb#Endianness) for a refresher on endianness.\n",
+    "\n",
     "### Q# materials\n",
     "\n",
     "* Using controlled and adjoint versions of gates is covered in the Q# documentation on [operation types](https://docs.microsoft.com/quantum/language/type-model#operation-and-function-types)."

--- a/BasicGates/Tasks.qs
+++ b/BasicGates/Tasks.qs
@@ -153,7 +153,7 @@ namespace Quantum.Kata.BasicGates {
     //////////////////////////////////////////////////////////////////
     // Part II. Multi-Qubit Gates
     //////////////////////////////////////////////////////////////////
-
+    // In the following tasks the order of qubit states in task description matches the order of qubits in the array (i.e.,  |10⟩  state corresponds to qs[0] in state  |1⟩  and qs[1] in state  |0⟩ ).
     // Task 2.1. Two-qubit gate - 1
     // Input: Two unentangled qubits (stored in an array of length 2).
     //        The first qubit will be in state |ψ⟩ = α |0⟩ + β |1⟩, the second - in state |0⟩

--- a/BasicGates/Tasks.qs
+++ b/BasicGates/Tasks.qs
@@ -153,7 +153,10 @@ namespace Quantum.Kata.BasicGates {
     //////////////////////////////////////////////////////////////////
     // Part II. Multi-Qubit Gates
     //////////////////////////////////////////////////////////////////
-    // In the following tasks the order of qubit states in task description matches the order of qubits in the array (i.e.,  |10⟩  state corresponds to qs[0] in state  |1⟩  and qs[1] in state  |0⟩ ).
+    // In the following tasks the order of qubit states in task description matches the order of qubits in the array 
+    // (i.e.,  |10⟩  state corresponds to qs[0] in state |1⟩ and qs[1] in state |0⟩).
+    // Note also that the states shown in test output use little-endian notation (similarly to DumpMachine), 
+    // see tutorial MultiQubitGates, for a refresher on endianness.
     // Task 2.1. Two-qubit gate - 1
     // Input: Two unentangled qubits (stored in an array of length 2).
     //        The first qubit will be in state |ψ⟩ = α |0⟩ + β |1⟩, the second - in state |0⟩


### PR DESCRIPTION
After finishing `MultiQubitSystems` and `MultiQubitGates` tutorials and tackling Part II of `Basic Gates` kata, I thought the little-endian notation would be de-facto notation for all katas. For instance this is the notation used in the `DumpMachine` instruction.

I believe that mentioning big-endian is the notation used in this kata could be useful and avoid some confusion from learners.