### PR TITLE
Update to Jupyter Core 1.3.

### DIFF
--- a/utilities/Microsoft.Quantum.Katas/CheckKataMagic.cs
+++ b/utilities/Microsoft.Quantum.Katas/CheckKataMagic.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Jupyter.Core;
 using Microsoft.Quantum.IQSharp;
@@ -20,7 +21,30 @@ namespace Microsoft.Quantum.Katas
         public CheckKataMagic(IOperationResolver resolver, ICompilerService compiler, ILogger<KataMagic> logger)
         {
             this.Name = $"%check_kata";
-            this.Documentation = new Documentation() { Summary = "Checks the resference implementaiton of a single kata's test." };
+            this.Documentation = new Documentation() { Summary = "Checks the reference implementation for a single kata's test." };
+            this.Documentation = new Documentation
+            {
+                Summary = "Checks the reference implementation for a single kata's test.",
+                Description =
+                    "Substitutes the reference implementation for a " +
+                    "single task into the cell, and reports whether the test " +
+                    "passed successfully using the reference implementation.",
+                Examples = new []
+                {
+                    "To check a test called `Test`:\n" +
+                    "```\n" +
+                    "In []: %check_kata T101_StateFlip_Test \n",
+                    "  ...: operation StateFlip (q : Qubit) : Unit is Adj + Ctl {\n",
+                    "           // The Pauli X gate will change the |0⟩ state to the |1⟩ state and vice versa.\n",
+                    "           // Type X(q);\n",
+                    "           // Then run the cell using Ctrl/⌘+Enter.\n",
+                    "\n",
+                    "           // ...\n",
+                    "       }\n" +
+                    "Out[]: Success!" +
+                    "```\n"
+                }
+            };
             this.Kind = SymbolKind.Magic;
             this.Execute = this.Run;
 
@@ -47,7 +71,7 @@ namespace Microsoft.Quantum.Katas
         /// - semi-compile the code after to identify the name of the operation with the user's answer.
         /// - call simulate to execute the test.
         /// </summary>
-        public virtual ExecutionResult Run(string input, IChannel channel)
+        public virtual async Task<ExecutionResult> Run(string input, IChannel channel)
         {
             channel = channel.WithNewLines();
 

--- a/utilities/Microsoft.Quantum.Katas/KataMagic.cs
+++ b/utilities/Microsoft.Quantum.Katas/KataMagic.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using System.Linq;
 using Microsoft.Extensions.Logging;
 using Microsoft.Jupyter.Core;
@@ -21,7 +22,29 @@ namespace Microsoft.Quantum.Katas
         public KataMagic(IOperationResolver resolver, ISnippets snippets, ILogger<KataMagic> logger)
         {
             this.Name = $"%kata";
-            this.Documentation = new Documentation() { Summary = "Executes a single test.", Full = "## Executes a single test.\n##Usage: \n%kata Test \"q# operation\"" };
+            this.Documentation = new Documentation
+            {
+                Summary = "Executes a single test.",
+                Description = "Executes a single test, and reports whether the test passed successfully.",
+                Examples = new []
+                {
+                    "To run a test called `Test`:\n" +
+                    "```\n" +
+                    "In []: %kata T101_StateFlip_Test \n",
+                    "  ...: operation StateFlip (q : Qubit) : Unit is Adj + Ctl {\n",
+                    "           // The Pauli X gate will change the |0⟩ state to the |1⟩ state and vice versa.\n",
+                    "           // Type X(q);\n",
+                    "           // Then run the cell using Ctrl/⌘+Enter.\n",
+                    "\n",
+                    "           // ...\n",
+                    "       }\n" +
+                    "Out[]: Qubit in invalid state. Expecting: Zero\n" +
+	                "       \tExpected:\t0\n"+
+	                "       \tActual:\t0.5000000000000002\n" +
+                    "       Try again!" +
+                    "```\n"
+                }
+            };
             this.Kind = SymbolKind.Magic;
             this.Execute = this.Run;
 
@@ -51,7 +74,7 @@ namespace Microsoft.Quantum.Katas
         /// - compile the code after found after the name as the user's answer.
         /// - run (simulate) the test and report its result.
         /// </summary>
-        public virtual ExecutionResult Run(string input, IChannel channel)
+        public virtual async Task<ExecutionResult> Run(string input, IChannel channel)
         {
             channel = channel.WithNewLines();
 

--- a/utilities/Microsoft.Quantum.Katas/Microsoft.Quantum.Katas.csproj
+++ b/utilities/Microsoft.Quantum.Katas/Microsoft.Quantum.Katas.csproj
@@ -17,8 +17,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Jupyter.Core" Version="1.1.18837" />
-    <PackageReference Include="Microsoft.Quantum.IQSharp.Core" Version="0.10.2003.1606-beta" />
+    <PackageReference Include="Microsoft.Jupyter.Core" Version="1.3.52077" />
+    <PackageReference Include="Microsoft.Quantum.IQSharp.Core" Version="0.11.2004.804-beta" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR updates the dependency from the Microsoft.Quantum.Katas package to Microsoft.Jupyter.Core to version 1.3, and uses new functionality in that version to provide extended documentation about the `%kata` and `%check_kata` magic commands.