### PR TITLE
Fix typo in Linear Algebra - Tensor Product

### DIFF
--- a/tutorials/LinearAlgebra/LinearAlgebra.ipynb
+++ b/tutorials/LinearAlgebra/LinearAlgebra.ipynb
@@ -991,7 +991,7 @@
    "source": [
     "The tensor product has the following properties:\n",
     "\n",
-    "* Distributivity over addiotion: $(A + B) \\otimes C = A \\otimes C + B \\otimes C$, $A \\otimes (B + C) = A \\otimes B + A \\otimes C$\n",
+    "* Distributivity over addition: $(A + B) \\otimes C = A \\otimes C + B \\otimes C$, $A \\otimes (B + C) = A \\otimes B + A \\otimes C$\n",
     "* Associativity with scalar multiplication: $x(A \\otimes B) = (xA) \\otimes B = A \\otimes (xB)$\n",
     "* Mixed-product property (relation with matrix multiplication): $(A \\otimes B) (C \\otimes D) = (AC) \\otimes (BD)$"
    ]


### PR DESCRIPTION
"Distributivity over addi**o**tion" should be spelled "Distributivity over addition"