### PR TITLE
Set IQ# HostingEnvironment to "build-agent"

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,7 +12,7 @@ variables:
   Build.Patch: $(Build.BuildId)
   Build.Configuration: 'Release'
   Drops.Dir: $(Build.ArtifactStagingDirectory)/drops
-
+  IQSharp.Hosting.Env: 'build-agent-katas'
 
 jobs:
 - job: Windows


### PR DESCRIPTION
This PR sets IQ# HostingEnvironment to "build-agent" in order to identify telemetry coming from CI processes.