### PR TITLE
Missing sqrt in Hardy State workbook

### DIFF
--- a/Superposition/Workbook_Superposition_Part2.ipynb
+++ b/Superposition/Workbook_Superposition_Part2.ipynb
@@ -922,7 +922,7 @@
     "\n",
     "$$|00\\rangle \\overset{R_{y_1}}\\rightarrow \\big (\\sqrt{\\frac{10}{12}}|0\\rangle + \\sqrt{\\frac{2}{12}}|1\\rangle \\big ) \\otimes |0\\rangle =: |\\psi_1\\rangle$$\n",
     "\n",
-    "Here $R_{y_1} := R_y(2\\arccos \\frac{10}{12}) \\otimes I$."
+    "Here $R_{y_1} := R_y(2\\arccos \\sqrt{\\frac{10}{12}}) \\otimes I$."
    ]
   },
   {


### PR DESCRIPTION
I spotted a missing sqrt() in the Superposition Workbook, for the Ry1 angle in "Task 2.5. Hardy state"