### PR TITLE
Add implementation of QPE based on QFT

### DIFF
--- a/PhaseEstimation/ReferenceImplementation.qs
+++ b/PhaseEstimation/ReferenceImplementation.qs
@@ -108,14 +108,14 @@ namespace Quantum.Kata.PhaseEstimation {
             // Apply controlled U gates so that |k⟩ gets transformed into exp(2πikθ)|k⟩.
             // Here |k⟩ is encoded in little-endian format in phaseRegister.
             for (i in 0 .. n - 1) {
-                let powU = UnitaryPower(U, 1 <<< i); // powU = U^(2^i)
+                let powU = UnitaryPower_Reference(U, 1 <<< i); // powU = U^(2^i)
                 Controlled powU([phaseRegister[i]], eigenstate);
             }
 
             // Apply an inverse QFT to phaseRegister.
             // We use QFTLE because phaseRegister is little-endian encoded.
             // This leaves phaseRegister in a superposition of integers which are close to θ*2^n.
-            // See the linked Wikipedia article on the details of this supoerposition.
+            // See the linked Wikipedia article on the details of this superposition.
             Adjoint QFTLE(LittleEndian(phaseRegister));
 
             // Measure out an integer that is close to θ*2^n.


### PR DESCRIPTION
Added per discussion here: https://github.com/microsoft/QuantumKatas/issues/328#issuecomment-638678626.

I decided to forgo the edits to Task 2.2 since the current solution is more representative of how iterative phase estimation is done in practice (i.e. using measurement + classical inference). I think edits to 2.2 are better done when Part II is fleshed out more, which is currently a TODO as can be seen from this line https://github.com/microsoft/QuantumKatas/blob/9d4f42cb8ee2b68a31a1be649c7a4ef02fe3ddca/PhaseEstimation/Tasks.qs#L172
