### PR TITLE
Removed Erroneous Note From Linear Algebra Tutorial

### DIFF
--- a/tutorials/LinearAlgebra/LinearAlgebra.ipynb
+++ b/tutorials/LinearAlgebra/LinearAlgebra.ipynb
@@ -1084,8 +1084,6 @@
     "\n",
     "**Output:** Return a real number - the eigenvalue of $A$ that is associated with the given eigenvector.\n",
     "\n",
-    "> Note that in this task the matrices are real-valued.\n",
-    "\n",
     "<br/>\n",
     "<details>\n",
     "    <summary><strong>Need a hint? Click here</strong></summary>\n",
@@ -1168,7 +1166,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
On the Linear Algebra Tutorial, exercise 13 "Finding an eigenvalue", there is a note that explains all matrices in this exercise are real-valued. This does not seem to be the case as the testing logic generates complex-valued matrices. This PR removes that note.