### PR TITLE
Update Katas to use Quantum.SDK

### DIFF
--- a/BasicGates/BasicGates.csproj
+++ b/BasicGates/BasicGates.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.11.2006.403">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
@@ -7,8 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.11.2006.403" />
-    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.11.2006.403" />
     <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.11.2006.403" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />

--- a/CHSHGame/CHSHGame.csproj
+++ b/CHSHGame/CHSHGame.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.11.2006.403">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
@@ -7,8 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.11.2006.403" />
-    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.11.2006.403" />
     <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.11.2006.403" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />

--- a/DeutschJozsaAlgorithm/DeutschJozsaAlgorithm.csproj
+++ b/DeutschJozsaAlgorithm/DeutschJozsaAlgorithm.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.11.2006.403">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
@@ -6,8 +6,6 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.11.2006.403" />
-    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.11.2006.403" />
     <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.11.2006.403" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />

--- a/DistinguishUnitaries/DistinguishUnitaries.csproj
+++ b/DistinguishUnitaries/DistinguishUnitaries.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.Quantum.Sdk/0.11.2006.403">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
@@ -7,8 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.11.2006.403" />
-    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.11.2006.403" />
     <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.11.2006.403" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />

--- a/GHZGame/GHZGame.csproj
+++ b/GHZGame/GHZGame.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.11.2006.403">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
@@ -7,8 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.11.2006.403" />
-    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.11.2006.403" />
     <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.11.2006.403" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />

--- a/GraphColoring/GraphColoring.csproj
+++ b/GraphColoring/GraphColoring.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.11.2006.403">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
@@ -7,8 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.11.2006.403" />
-    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.11.2006.403" />
     <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.11.2006.403" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />

--- a/GroversAlgorithm/GroversAlgorithm.csproj
+++ b/GroversAlgorithm/GroversAlgorithm.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.11.2006.403">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
@@ -7,8 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.11.2006.403" />
-    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.11.2006.403" />
     <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.11.2006.403" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />

--- a/JointMeasurements/JointMeasurements.csproj
+++ b/JointMeasurements/JointMeasurements.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.11.2006.403">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
@@ -7,8 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.11.2006.403" />
-    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.11.2006.403" />
     <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.11.2006.403" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />

--- a/KeyDistribution_BB84/KeyDistribution_BB84.csproj
+++ b/KeyDistribution_BB84/KeyDistribution_BB84.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.11.2006.403">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
@@ -7,8 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.11.2006.403" />
-    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.11.2006.403" />
     <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.11.2006.403" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />

--- a/MagicSquareGame/MagicSquareGame.csproj
+++ b/MagicSquareGame/MagicSquareGame.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.11.2006.403">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
@@ -7,8 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.11.2006.403" />
-    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.11.2006.403" />
     <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.11.2006.403" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />

--- a/Measurements/Measurements.csproj
+++ b/Measurements/Measurements.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.11.2006.403">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
@@ -7,8 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.11.2006.403" />
-    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.11.2006.403" />
     <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.11.2006.403" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />

--- a/PhaseEstimation/PhaseEstimation.csproj
+++ b/PhaseEstimation/PhaseEstimation.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.11.2006.403">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
@@ -7,8 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.11.2006.403" />
-    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.11.2006.403" />
     <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.11.2006.403" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />

--- a/QEC_BitFlipCode/QEC_BitFlipCode.csproj
+++ b/QEC_BitFlipCode/QEC_BitFlipCode.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.11.2006.403">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
@@ -10,8 +10,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.11.2006.403" />
-    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.11.2006.403" />
     <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.11.2006.403" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />

--- a/QFT/QFT.csproj
+++ b/QFT/QFT.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.11.2006.403">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
@@ -7,8 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.11.2006.403" />
-    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.11.2006.403" />
     <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.11.2006.403" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />

--- a/RippleCarryAdder/RippleCarryAdder.csproj
+++ b/RippleCarryAdder/RippleCarryAdder.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.11.2006.403">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
@@ -7,8 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.11.2006.403" />
-    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.11.2006.403" />
     <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.11.2006.403" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />

--- a/SimonsAlgorithm/SimonsAlgorithm.csproj
+++ b/SimonsAlgorithm/SimonsAlgorithm.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.11.2006.403">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
@@ -7,8 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.11.2006.403" />
-    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.11.2006.403" />
     <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.11.2006.403" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />

--- a/SolveSATWithGrover/SolveSATWithGrover.csproj
+++ b/SolveSATWithGrover/SolveSATWithGrover.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.11.2006.403">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
@@ -7,8 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.11.2006.403" />
-    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.11.2006.403" />
     <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.11.2006.403" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />

--- a/SuperdenseCoding/SuperdenseCoding.csproj
+++ b/SuperdenseCoding/SuperdenseCoding.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.11.2006.403">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
@@ -7,8 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.11.2006.403" />
-    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.11.2006.403" />
     <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.11.2006.403" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />

--- a/Superposition/Superposition.csproj
+++ b/Superposition/Superposition.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.11.2006.403">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
@@ -7,8 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.11.2006.403" />
-    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.11.2006.403" />
     <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.11.2006.403" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />

--- a/Teleportation/Teleportation.csproj
+++ b/Teleportation/Teleportation.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.11.2006.403">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
@@ -7,8 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.11.2006.403" />
-    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.11.2006.403" />
     <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.11.2006.403" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />

--- a/TruthTables/TruthTables.csproj
+++ b/TruthTables/TruthTables.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.11.2006.403">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
@@ -7,8 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.11.2006.403" />
-    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.11.2006.403" />
     <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.11.2006.403" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />

--- a/UnitaryPatterns/UnitaryPatterns.csproj
+++ b/UnitaryPatterns/UnitaryPatterns.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.11.2006.403">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
@@ -7,8 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.11.2006.403" />
-    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.11.2006.403" />
     <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.11.2006.403" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />

--- a/tutorials/ExploringDeutschJozsaAlgorithm/DeutschJozsaAlgorithmTutorial.csproj
+++ b/tutorials/ExploringDeutschJozsaAlgorithm/DeutschJozsaAlgorithmTutorial.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.11.2006.403">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
@@ -6,8 +6,6 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.11.2006.403" />
-    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.11.2006.403" />
     <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.11.2006.403" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />

--- a/tutorials/ExploringGroversAlgorithm/ExploringGroversAlgorithmTutorial.csproj
+++ b/tutorials/ExploringGroversAlgorithm/ExploringGroversAlgorithmTutorial.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.11.2006.403">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
@@ -6,8 +6,6 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.11.2006.403" />
-    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.11.2006.403" />
     <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.11.2006.403" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />

--- a/tutorials/MultiQubitGates/MultiQubitGates.csproj
+++ b/tutorials/MultiQubitGates/MultiQubitGates.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.11.2006.403">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
@@ -6,8 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.11.2006.403" />
-    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.11.2006.403" />
     <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.11.2006.403" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />

--- a/tutorials/MultiQubitSystems/MultiQubitSystems.csproj
+++ b/tutorials/MultiQubitSystems/MultiQubitSystems.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.11.2006.403">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
@@ -6,8 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.11.2006.403" />
-    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.11.2006.403" />
     <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.11.2006.403" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />

--- a/tutorials/SingleQubitGates/SingleQubitGates.csproj
+++ b/tutorials/SingleQubitGates/SingleQubitGates.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.11.2006.403">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
@@ -6,8 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.11.2006.403" />
-    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.11.2006.403" />
     <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.11.2006.403" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />

--- a/utilities/Common/Common.csproj
+++ b/utilities/Common/Common.csproj
@@ -1,13 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.11.2006.403">
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <AssemblyName>Microsoft.Quantum.Katas.Common</AssemblyName>
   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.11.2006.403" />
-  </ItemGroup>
-  
 </Project>

--- a/utilities/DumpUnitary/DumpUnitary.csproj
+++ b/utilities/DumpUnitary/DumpUnitary.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.11.2006.403">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
@@ -6,10 +6,5 @@
   </PropertyGroup>
   <ItemGroup>
     <None Include="README.md" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.11.2006.403" />
-    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.11.2006.403" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
The `Microsoft.Quantum.SDK` is now preferred over the `Microsoft.Quantum.Development.Kit` for those projects that require to compile Q# files.
Updating all projects accordingly.