### PR TITLE
Fixed Minor Numbering Typo Exercise 5 -> Exercise 6

### DIFF
--- a/tutorials/SingleQubitGates/Tasks.qs
+++ b/tutorials/SingleQubitGates/Tasks.qs
@@ -41,7 +41,7 @@ namespace Quantum.Kata.SingleQubitGates {
         
     }
 
-    // Exercise 5.
+    // Exercise 6.
     operation PrepareRotatedState (alpha : Double, beta : Double, q : Qubit) : Unit is Adj+Ctl {
         // ...
         


### PR DESCRIPTION
The 6th Exercise should be labelled Exercise 6 but it is currently labelled Exercise 5