### PR TITLE
[RippleCarryAdder] Minor Typo Fix engian -> endian

### DIFF
--- a/RippleCarryAdder/RippleCarryAdder.ipynb
+++ b/RippleCarryAdder/RippleCarryAdder.ipynb
@@ -310,7 +310,7 @@
     "\n",
     "**Goals:**\n",
     "\n",
-    "* Transform the `sum` register into the binary sum (little-engian) of $\\phi$ and $\\psi$.\n",
+    "* Transform the `sum` register into the binary sum (little-endian) of $\\phi$ and $\\psi$.\n",
     "* Transform the `carry` qubit into the carry bit produced by that sum.\n",
     "\n",
     "**Challenge:**\n",


### PR DESCRIPTION
RippleCarryAdder Task 1.7 Goal Description has a spelling mistake. I just fixed that