### PR TITLE
[TruthTables] MinorFix Q# conditional expressions has else as vertical bar '|' not colon ':'.

### DIFF
--- a/TruthTables/Tasks.qs
+++ b/TruthTables/Tasks.qs
@@ -110,7 +110,7 @@ namespace Quantum.Kata.TruthTables {
 
     // Task 6. Build if-then-else truth table
     //
-    // Goal: Compute the truth table of the if-then-else function ttCond ? ttThen : ttElse
+    // Goal: Compute the truth table of the if-then-else function ttCond ? ttThen | ttElse
     //       (if ttCond then ttThen else ttElse) by making use of the truth table operations
     //       defined in the previous 4 tasks.
     function TTIfThenElse (ttCond : TruthTable, ttThen : TruthTable, ttElse : TruthTable) : TruthTable {

--- a/TruthTables/TruthTables.ipynb
+++ b/TruthTables/TruthTables.ipynb
@@ -278,7 +278,7 @@
    "source": [
     "### Task 6. Build if-then-else truth table\n",
     "**Goal:** \n",
-    "Compute the truth table of the if-then-else function `ttCond ? ttThen : ttElse`\n",
+    "Compute the truth table of the if-then-else function `ttCond ? ttThen | ttElse`\n",
     "(`if ttCond then ttThen else ttElse`) by making use of the truth table operations\n",
     "defined in the previous four tasks."
    ]


### PR DESCRIPTION
I spotted this in TruthTables Kata. I think C style syntax was used here as most people are familiar with ```if ? then : else``` while Q# has ```if ? then | else```. 
Since Katas are about learning Q# , I believe for consistency we should use ```|``` not ```:```.