### PR TITLE
[SolveSATWithGrover] Minor Indexing Error Fixed

### DIFF
--- a/SolveSATWithGrover/SolveSATWithGrover.ipynb
+++ b/SolveSATWithGrover/SolveSATWithGrover.ipynb
@@ -233,7 +233,7 @@
     "> For SAT problems, $f(x)$ is represented as a conjunction (an AND operation) of several clauses on $N$ variables,\n",
     "and each clause is a disjunction (an OR operation) of **one or several** variables or negated variables:\n",
     ">\n",
-    "> $$clause(x) = \\bigvee_k y_{ik},\\text{ where }y_{ik} =\\text{ either }x_j\\text{ or }\\neg x_j\\text{ for some }j \\in \\{0, \\dots, N-1\\}$$\n",
+    "> $$clause(x) = \\bigvee_k y_{k},\\text{ where }y_{k} =\\text{ either }x_j\\text{ or }\\neg x_j\\text{ for some }j \\in \\{0, \\dots, N-1\\}$$\n",
     ">\n",
     "> For example, one of the possible clauses on two variables is:\n",
     ">\n",

--- a/SolveSATWithGrover/Tasks.qs
+++ b/SolveSATWithGrover/Tasks.qs
@@ -103,7 +103,7 @@ namespace Quantum.Kata.GroversAlgorithm {
     // 
     // For general SAT problems, f(x) is represented as a conjunction (an AND operation) of several clauses on N variables, 
     // and each clause is a disjunction (an OR operation) of one or several variables or negated variables:
-    //      clause(x) = ∨ₖ yᵢₖ, where yᵢₖ = either xⱼ or ¬xⱼ for some j in {0, ..., N-1}
+    //      clause(x) = ∨ₖ yₖ, where yₖ = either xⱼ or ¬xⱼ for some j in {0, ..., N-1}
     // 
     // For example, one of the possible clauses on two variables is 
     //      clause(x) = x₀ ∨ ¬x₁


### PR DESCRIPTION
The clause index for 1 clause k-sat problem should simply be $y_{k}$ instead of $y_{ik}$. There is no iteration over i here - that occurs in Task 1.6 where there are more than one clause and $i$ is an index over those.