### PR TITLE
[CI] Fix false positives in projects verification

### DIFF
--- a/BasicGates/ReferenceImplementation.qs
+++ b/BasicGates/ReferenceImplementation.qs
@@ -175,7 +175,7 @@ namespace Quantum.Kata.BasicGates {
     // Goal:  Swap the states of second and third qubit if and only if the state of the first qubit is |1⟩:
     //        i.e., change the three-qubit state to
     //        α|000⟩ + β|001⟩ + γ|010⟩ + δ|011⟩ + ε|100⟩ + η|101⟩ + ζ|110⟩ + θ|111⟩.
-    operation FredkinGate_Reference (qs : Qubit[]) : Unit {
+    operation FredkinGate_Reference (qs : Qubit[]) : Unit is Adj+Ctl {
         Controlled SWAP([qs[0]], (qs[1], qs[2]));
     }
 

--- a/BasicGates/ReferenceImplementation.qs
+++ b/BasicGates/ReferenceImplementation.qs
@@ -175,7 +175,7 @@ namespace Quantum.Kata.BasicGates {
     // Goal:  Swap the states of second and third qubit if and only if the state of the first qubit is |1⟩:
     //        i.e., change the three-qubit state to
     //        α|000⟩ + β|001⟩ + γ|010⟩ + δ|011⟩ + ε|100⟩ + η|101⟩ + ζ|110⟩ + θ|111⟩.
-    operation FredkinGate_Reference (qs : Qubit[]) : Unit is Adj+Ctl {
+    operation FredkinGate_Reference (qs : Qubit[]) : Unit {
         Controlled SWAP([qs[0]], (qs[1], qs[2]));
     }
 

--- a/scripts/validate-projects.ps1
+++ b/scripts/validate-projects.ps1
@@ -4,7 +4,7 @@
 $ErrorActionPreference = 'Stop'
 
 & "$PSScriptRoot/set-env.ps1"
-
+$all_ok = $True
 
 function Build-One {
   param(
@@ -22,6 +22,10 @@ function Build-One {
   $script:all_ok = ($LastExitCode -eq 0) -and $script:all_ok
 }
 
-# Build all Katas solutions:
+# Build all Katas solutions
 Get-ChildItem (Join-Path $PSScriptRoot '..') -Recurse -Include '*.sln' -Exclude 'Microsoft.Quantum.Katas.sln' `
 | ForEach-Object { Build-One $_.FullName }
+
+if (-not $all_ok) {
+    throw "At least one project failed building. Check the logs."
+}


### PR DESCRIPTION
#410 split project build into separate jobs, but missed moving $all_ok variable check from the old script to the new one. This caused build jobs to always report success, even if `dotnet build` fails. This change adds $all_ok variable to store and report build status.