### PR TITLE
[GrahColoring] task 1.5: add check that the solution doesn't allocate…

### DIFF
--- a/GraphColoring/GraphColoring.csproj
+++ b/GraphColoring/GraphColoring.csproj
@@ -15,6 +15,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\utilities\Common\Common.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Include="README.md" />
   </ItemGroup>
 </Project>

--- a/GraphColoring/TestSuiteRunner.cs
+++ b/GraphColoring/TestSuiteRunner.cs
@@ -11,6 +11,7 @@ using Microsoft.Quantum.Simulation.XUnit;
 using Microsoft.Quantum.Simulation.Simulators;
 using Xunit.Abstractions;
 using System.Diagnostics;
+using Microsoft.Quantum.Katas;
 
 namespace Quantum.Kata.GraphColoring
 {
@@ -30,7 +31,7 @@ namespace Quantum.Kata.GraphColoring
         [OperationDriver(TestNamespace = "Quantum.Kata.GraphColoring")]
         public void TestTarget(TestOperation op)
         {
-            using (var sim = new QuantumSimulator())
+            using (var sim = new CounterSimulator())
             {
                 // OnLog defines action(s) performed when Q# test calls function Message
                 sim.OnLog += (msg) => { output.WriteLine(msg); };

--- a/GraphColoring/Tests.qs
+++ b/GraphColoring/Tests.qs
@@ -16,6 +16,7 @@ namespace Quantum.Kata.GraphColoring {
     open Microsoft.Quantum.Convert;
     open Microsoft.Quantum.Math;
     open Microsoft.Quantum.Diagnostics;
+    open Quantum.Kata.Utils;
     
 
     //////////////////////////////////////////////////////////////////
@@ -133,10 +134,14 @@ namespace Quantum.Kata.GraphColoring {
     // ------------------------------------------------------
     operation T15_ColorEqualityOracle_Nbit_Test () : Unit {
         for (N in 1..4) {
+            ResetQubitCount();
+            
             CheckColorEqualityOracle(N, ColorEqualityOracle_Nbit);
             AssertOperationsEqualReferenced(2*N+1, WrapperOperation(ColorEqualityOracle_Nbit, _),
                                                    WrapperOperation(ColorEqualityOracle_Nbit_Reference, _));
-            // TODO: verify that the oracle doesn't allocate extra qubits
+
+            let nq = GetMaxQubitCount();
+            EqualityFactI(nq, 2*N+1, $"You are not allowed to allocate extra qubits. You allocated {nq - (2*N+1)}");
         }
     }
 


### PR DESCRIPTION
GraphColoring kata, task 1.5: add check that the solution doesn’t allocate extra qubit. 
used CounterSimulator and GetMaxQubitCount () operation, inspired by :
https://github.com/microsoft/QuantumKatas/blob/master/PhaseEstimation/Tests.qs#L118