### PR TITLE
Signing key path

### DIFF
--- a/utilities/Common/DelaySign.cs
+++ b/utilities/Common/DelaySign.cs
@@ -5,7 +5,7 @@ using System.Reflection;
 
 // Attributes for delay-signing
 #if SIGNED
-[assembly:AssemblyKeyFile("..\\..\\scripts\\267DevDivSNKey2048.snk")]
+[assembly:AssemblyKeyFile("../../scripts/267DevDivSNKey2048.snk")]
 [assembly:AssemblyDelaySign(true)]
 #endif
 


### PR DESCRIPTION
Changing signing key path so it is compatible in linux. Confirmed it works on Windows too.