### PR TITLE
Fix wrong initial state in Teleportation.ipynb

### DIFF
--- a/Teleportation/Teleportation.ipynb
+++ b/Teleportation/Teleportation.ipynb
@@ -414,7 +414,7 @@
    "source": [
     "### Task 4.1. Entangled trio\n",
     "\n",
-    "**Inputs:** three qubits qAlice, qBob, and qCharlie, each in $|10\\rangle$ state.\n",
+    "**Inputs:** three qubits qAlice, qBob, and qCharlie, each in $|0\\rangle$ state.\n",
     "\n",
     "**Goal:** create an entangled state $|\\Psi^{3}\\rangle = \\frac{1}{2} \\big(|000\\rangle + |011\\rangle + |101\\rangle + |110\\rangle\\big)$ on these qubits.\n",
     "\n",


### PR DESCRIPTION
In task 4.1 of the Teleportation kata, it's said that each of the qubits are "in |10⟩ state". Since one-qubit systems can't have the said state, I looked through the [tests](https://github.com/microsoft/QuantumKatas/blob/master/Teleportation/Tests.qs) and saw that each of the qubits are prepared in |0⟩ state, so I fixed that typo. xD