### PR TITLE
Extend ExecutePreprocessor.startup_timeout to 120

### DIFF
--- a/scripts/validate-notebooks.ps1
+++ b/scripts/validate-notebooks.ps1
@@ -64,10 +64,10 @@ function Validate {
     $ErrorActionPreference = 'Continue'
     if ($env:SYSTEM_DEBUG -eq "true") {
         # Redirect stderr output to stdout to prevent an exception being incorrectly thrown.
-        jupyter nbconvert $CheckNotebook --execute  --ExecutePreprocessor.timeout=120 --log-level=DEBUG 2>&1 | %{ "$_"}
+        jupyter nbconvert $CheckNotebook --execute --ExecutePreprocessor.startup_timeout=120 --ExecutePreprocessor.timeout=120 --log-level=DEBUG 2>&1 | %{ "$_"}
     } else {
         # Redirect stderr output to stdout to prevent an exception being incorrectly thrown.
-        jupyter nbconvert $CheckNotebook --execute  --ExecutePreprocessor.timeout=120 2>&1 | %{ "$_"}
+        jupyter nbconvert $CheckNotebook --execute --ExecutePreprocessor.startup_timeout=120 --ExecutePreprocessor.timeout=120 2>&1 | %{ "$_"}
     }
     $ErrorActionPreference = 'Stop'
 


### PR DESCRIPTION
Increasing the timeout to prevent a condition during CI validation in which a new package takes longer to load. 