### PR TITLE
Fixed Documentation of Simulate Function of %kata magic

### DIFF
--- a/utilities/Microsoft.Quantum.Katas/KataMagic.cs
+++ b/utilities/Microsoft.Quantum.Katas/KataMagic.cs
@@ -155,7 +155,7 @@ namespace Microsoft.Quantum.Katas
         /// <summary>
         /// Executes the given kata using the provided <c>userAnswer</c> as the actual answer.
         /// To do this, it finds another operation with the same name but in the Kata's namespace
-        /// (by calling `FindRawAnswer`) and replace its implementation with the userAnswer
+        /// (by calling `FindSkeltonAnswer`) and replace its implementation with the userAnswer
         /// in the simulator.
         /// </summary>
         public virtual bool Simulate(OperationInfo test, OperationInfo userAnswer, IChannel channel)


### PR DESCRIPTION
Fixing documentation error for Simulate function in KataMagic.cs. FindSkelton Answer is now used instead of findRawAnswer to find operation with the same name but in the Kata's namespace. This is in reference to the the following issue https://github.com/microsoft/QuantumKatas/issues/466