### PR TITLE
[GraphColoring] Fixed missing right hand bracket ')' in Task 1.4

### DIFF
--- a/GraphColoring/GraphColoring.ipynb
+++ b/GraphColoring/GraphColoring.ipynb
@@ -145,7 +145,7 @@
     "\n",
     "**Goal:**\n",
     "\n",
-    "Transform state $|c_{0}\\rangle|c_{1}\\rangle|y\\rangle$ into state $|c_{0}\\rangle|c_{1}\\rangle|y \\oplus f(c_{0},c_{1}\\rangle$ ($\\oplus$ is addition modulo 2), \n",
+    "Transform state $|c_{0}\\rangle|c_{1}\\rangle|y\\rangle$ into state $|c_{0}\\rangle|c_{1}\\rangle|y \\oplus f(c_{0},c_{1})\\rangle$ ($\\oplus$ is addition modulo 2), \n",
     "where $f(x) = 1$ if $c_{0}$ and $c_{1}$ are in the same state, and 0 otherwise. \n",
     "Leave the query register in the same state it started in.\n",
     "\n",


### PR DESCRIPTION
While I was working on the Workbook, I noticed this error. This PR is the fix for that.