### PR TITLE
Improve CI performance

### DIFF
--- a/scripts/validate-notebooks.ps1
+++ b/scripts/validate-notebooks.ps1
@@ -37,10 +37,6 @@ Param(
 & "$PSScriptRoot/install-iqsharp.ps1"
 $all_ok = $True
 
-# Restore all Katas solutions to populate NuGet cache
-Get-ChildItem (Join-Path $PSScriptRoot '..') -Recurse -Include '*.sln' -Exclude 'Microsoft.Quantum.Katas.sln' `
-| ForEach-Object { dotnet restore $_.FullName }
-
 function Validate {
     Param($Notebook)
 
@@ -69,7 +65,10 @@ function Validate {
     (Get-Content $Notebook -Raw) | ForEach-Object { $_.replace('%kata', '%check_kata') } | Set-Content $CheckNotebook -NoNewline
 
     try {
-        # Disable NuGet package loading, since all necessary packages should be cached at this point
+        # Populate NuGet cache for this project
+        dotnet restore
+
+        # Disable NuGet package loading, since all required packages should be cached at this point
         "<?xml version=""1.0"" encoding=""utf-8""?>
             <configuration>
                 <packageSources>

--- a/scripts/validate-notebooks.ps1
+++ b/scripts/validate-notebooks.ps1
@@ -68,7 +68,7 @@ function Validate {
         # Populate NuGet cache for this project
         dotnet restore
 
-        # Disable NuGet package loading, since all required packages should be cached at this point
+        # Clear NuGet package sources, since all required packages should be cached at this point
         "<?xml version=""1.0"" encoding=""utf-8""?>
             <configuration>
                 <packageSources>

--- a/scripts/validate-notebooks.ps1
+++ b/scripts/validate-notebooks.ps1
@@ -79,11 +79,17 @@ function Validate {
         " | Out-File ./NuGet.Config -Encoding utf8
 
         # Run Jupyter nbconvert to execute the kata.
+        # dotnet-iqsharp writes some output to stderr, which causes PowerShell to throw
+        # unless $ErrorActionPreference is set to 'Continue'.
+        $ErrorActionPreference = 'Continue'
         if ($env:SYSTEM_DEBUG -eq "true") {
-            jupyter nbconvert $CheckNotebook --execute --to html --ExecutePreprocessor.timeout=300 --log-level=DEBUG
+            # Redirect stderr output to stdout to prevent an exception being incorrectly thrown.
+            jupyter nbconvert $CheckNotebook --execute --to html --ExecutePreprocessor.timeout=300 --log-level=DEBUG 2>&1 | %{ "$_"}
         } else {
-            jupyter nbconvert $CheckNotebook --execute --to html --ExecutePreprocessor.timeout=300
+            # Redirect stderr output to stdout to prevent an exception being incorrectly thrown.
+            jupyter nbconvert $CheckNotebook --execute --to html --ExecutePreprocessor.timeout=300 2>&1 | %{ "$_"}
         }
+        $ErrorActionPreference = 'Stop'
 
         # if jupyter returns an error code, report that this notebook is invalid:
         if ($LastExitCode -ne 0) {


### PR DESCRIPTION
This change improves the performance of Katas CI runs by caching NuGet packages in advance via `dotnet restore` and then clearing all NuGet package sources while executing the notebooks.

This should reduce the total CI runtime to around 15 minutes in the typical case.