### PR TITLE
[GraphColoring] Fix qubit allocation check in task 1.5

### DIFF
--- a/GraphColoring/Tests.qs
+++ b/GraphColoring/Tests.qs
@@ -141,11 +141,12 @@ namespace Quantum.Kata.GraphColoring {
             ResetQubitCount();
             
             CheckColorEqualityOracle(N, ColorEqualityOracle_Nbit);
-            AssertOperationsEqualReferenced(2*N+1, WrapperOperation(ColorEqualityOracle_Nbit, _),
-                                                   WrapperOperation(ColorEqualityOracle_Nbit_Reference, _));
 
             let nq = GetMaxQubitCount();
             EqualityFactI(nq, 2*N+1, $"You are not allowed to allocate extra qubits. You allocated {nq - (2*N+1)}");
+
+            AssertOperationsEqualReferenced(2*N+1, WrapperOperation(ColorEqualityOracle_Nbit, _),
+                                                   WrapperOperation(ColorEqualityOracle_Nbit_Reference, _));
         }
     }
 


### PR DESCRIPTION
We need to check that the solution doesn't use more than 2N+1 qubits passed to it as an argument.
This check has to happen before AssertOperationsEqualReferenced call, since that operation allocates twice that many qubits to use Choi–Jamiłkowski isomorphism.

This was introduced in #446, and somehow I missed that the reference solution fails the test. GraphColoring kata is excluded from CI validation. This emphasizes the need for fixing https://github.com/microsoft/QuantumKatas/issues/485.