### PR TITLE
Add PrivateAssets="All" to IQ# package reference

### DIFF
--- a/utilities/Microsoft.Quantum.Katas/Microsoft.Quantum.Katas.csproj
+++ b/utilities/Microsoft.Quantum.Katas/Microsoft.Quantum.Katas.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.IQSharp.Jupyter" Version="0.12.20100504" />
+    <PackageReference Include="Microsoft.Quantum.IQSharp.Jupyter" Version="0.12.20100504" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This change improves the first-run performance of loading the `Microsoft.Quantum.Katas` package inside IQ# by telling NuGet to skip resolution of the IQ#-specific dependency, which is unnecessary since all IQ# assemblies are already available.

See https://github.com/microsoft/iqsharp/issues/338 and https://github.com/microsoft/QuantumLibraries/pull/351 for more background.

We are still investigating whether there's a more general change we can make in IQ# instead to avoid this issue, but this is a harmless change that should improve performance in the meantime.

**Note for the future:**
With this change, and after also updating the Katas to the next release to pick up https://github.com/microsoft/QuantumLibraries/pull/351, we should be able to undo the changes made in https://github.com/microsoft/QuantumKatas/pull/515 with negligible impact on CI performance. At that time we can likely also reduce the cell execution timeout in `validate-notebooks.ps1` significantly, perhaps back to 120 seconds as it was before. And we can remove the special error handling in that script, since there would no longer be any errors output by IQ# during the `jupyter nbconvert` call.

i.e., we should be able to replace this:
https://github.com/microsoft/QuantumKatas/blob/8b0ba657c65ce4ae49046a1bfa6222aed277bf6c/scripts/validate-notebooks.ps1#L81-L91

with just:
```
 if ($env:SYSTEM_DEBUG -eq "true") { 
     jupyter nbconvert $CheckNotebook --execute --to html --ExecutePreprocessor.timeout=120 --log-level=DEBUG
 } else { 
     jupyter nbconvert $CheckNotebook --execute --to html --ExecutePreprocessor.timeout=120
 } 
```