### PR TITLE
Updating notebooks validation script to exclude individual tasks

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -90,6 +90,16 @@ Updating the Katas to a different QDK version can be done using PowerShell scrip
 
 After running this script you should validate that the update didn't introduce any breaking changes; see the next section for how to do this.
 
+### Excluding the tasks so that CI doesn't fail
+Currently some tasks are excluded from validation by adding the appropriate cell tag to the task due to several reasons : 
+- Some tasks require implementing two code cells at once before running the test, so the first of the cells implemented is guaranteed to fail(```two_player_game```)
+-  There are some tasks for which the correct solution fails with relatively high probability(```failure_of_correct_solution```) or correct solution times out with relatively high probability(```timeout```)
+- There are some tasks with deliberately invalid code(```invalid_code```)
+- If the solutions to the tasks(Either in ReferenceImplementation or Workbook) are work in progress(```work_in_progress```).
+
+To do this, go to ```View -> Cell Toolbar -> Tags``` to see the cells that have been tagged and to add a new tag to a cell. If there is a new reason for some tasks to be excluded from validation, feel free to update the [exclude_from_validation set](https://github.com/microsoft/QuantumKatas/blob/main/scripts/validate-notebooks.ps1#L92) in ```validate-notebooks.ps1``` script. 
+
+PS : After adding the tags to the jupyter notebook, please do ```View -> Cell Toolbar -> None``` and save your changes through ```Ctrl+S``` or by hitting ```Save and Checkpoint``` button. This is necessary because we don't want learner to see the cell tags associated with each cell when they open the jupyter notebook.
 
 ### Validating your changes
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -5,18 +5,15 @@ We're so glad you asked!
 **Table of Contents**
 
 * [Reporting Bugs](#reporting-bugs)
-
 * [Improving Documentation](#improving-documentation)
-
 * [Contributing Code](#contributing-code)
    * [Improving existing katas](#improving-existing-katas)
    * [Contributing new katas](#contributing-new-katas)
    * [Style guide](#style-guide)
    * [Updating the Katas to the new QDK version](#updating-the-Katas-to-the-new-QDK-version)
    * [Validating your changes](#validating-your-changes)
-
+      * [Excluding individual tasks from validation](#excluding-individual-tasks-from-validation)
 * [Contributor License Agreement](#contributor-license-agreement)
-
 * [Code of Conduct](#code-of-conduct)
 
 ## Reporting Bugs
@@ -90,16 +87,6 @@ Updating the Katas to a different QDK version can be done using PowerShell scrip
 
 After running this script you should validate that the update didn't introduce any breaking changes; see the next section for how to do this.
 
-### Excluding the tasks so that CI doesn't fail
-Currently some tasks are excluded from validation by adding the appropriate cell tag to the task due to several reasons : 
-- Some tasks require implementing two code cells at once before running the test, so the first of the cells implemented is guaranteed to fail(```multicell_solution```)
--  There are some tasks for which the correct solution fails with relatively high probability(```randomized_solution```) or correct solution times out with relatively high probability(```timeout```)
-- There are some tasks with deliberately invalid code(```invalid_code```)
-
-To exclude tasks from validation, go to ```View -> Cell Toolbar -> Tags``` to see the cells that have been tagged and/or to add a new tag to a cell. If there is a new reason for some tasks to be excluded from validation, feel free to update the [exclude_from_validation set](https://github.com/microsoft/QuantumKatas/blob/main/scripts/validate-notebooks.ps1#L91) in ```validate-notebooks.ps1``` script and add an explaination for the new cell tag in ```validate-notebooks.ps1``` script and this contribution guide as well.
-
-PS : After adding the tags to the jupyter notebook, please do ```View -> Cell Toolbar -> None``` and save your changes through ```Ctrl+S``` or by hitting ```Save and Checkpoint``` button. This is necessary because we don't want learner to see the cell tags associated with each cell when they open the jupyter notebook.
-
 ### Validating your changes
 
 When you contribute any code to the Katas, you need to validate that everything works the way it is supposed to work. Here are the key points to check (they might or might not be applicable to your change, depending on what you modified):
@@ -129,6 +116,21 @@ and to [have PowerShell installed](https://github.com/PowerShell/PowerShell#get-
 
 3. **Continuous integration**  
    When you open a pull request or add a commit to it, continuous integration pipeline is executed to validate your changes. You can see the details of jobs executed in the "Checks" section on the pull request page; make sure to monitor the results, and if the run fails, try to figure out the reason and fix it.
+
+#### Excluding individual tasks from validation
+
+Currently some tasks are excluded from validation performed as part of continuous integration done by the [`scripts/validate-notebooks.ps1`](../scripts/validate-notebooks.ps1) script.
+This can happen for several reasons: 
+ - Some tasks require implementing several code cells at once before running the test, so the first of the cells implemented is guaranteed to fail the associated test (`multicell_solution`).
+ - For some tasks the correct solution is randomize and fails (`randomized_solution`) or times out (`timeout`) with relatively high probability.
+ - Some code cells contain deliberately invalid code (`invalid_code`) that the learner is supposed to fix.
+
+> Currently all tags are excluded from validation in the same way: the corresponding cells are not executed when the notebook is validated.
+> The different tags are introduced as a form of documenting the reasons for excluding the tasks.
+> If there is a new reason, you can update the `exclude_from_validation` set of tags in the [`scripts/validate-notebooks.ps1`](../scripts/validate-notebooks.ps1) script and add an explanation for the new tag in this contribution guide.
+
+To exclude a task from validation, open the corresponding Jupyter notebook and choose ```View -> Cell Toolbar -> Tags``` to see and edit the tags for each cell. Add the tag that is the most fitting description of the failure cause to the cell. 
+After you are done with editing the notebook, choose ```View -> Cell Toolbar -> None``` to turn off tags editing view for the subsequent users of this notebook. Finally, save the notebook.
 
 
 ## Contributor License Agreement

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -92,12 +92,11 @@ After running this script you should validate that the update didn't introduce a
 
 ### Excluding the tasks so that CI doesn't fail
 Currently some tasks are excluded from validation by adding the appropriate cell tag to the task due to several reasons : 
-- Some tasks require implementing two code cells at once before running the test, so the first of the cells implemented is guaranteed to fail(```two_player_game```)
--  There are some tasks for which the correct solution fails with relatively high probability(```failure_of_correct_solution```) or correct solution times out with relatively high probability(```timeout```)
+- Some tasks require implementing two code cells at once before running the test, so the first of the cells implemented is guaranteed to fail(```multicell_solution```)
+-  There are some tasks for which the correct solution fails with relatively high probability(```randomized_solution```) or correct solution times out with relatively high probability(```timeout```)
 - There are some tasks with deliberately invalid code(```invalid_code```)
-- If the solutions to the tasks(Either in ReferenceImplementation or Workbook) are work in progress(```work_in_progress```).
 
-To do this, go to ```View -> Cell Toolbar -> Tags``` to see the cells that have been tagged and to add a new tag to a cell. If there is a new reason for some tasks to be excluded from validation, feel free to update the [exclude_from_validation set](https://github.com/microsoft/QuantumKatas/blob/main/scripts/validate-notebooks.ps1#L92) in ```validate-notebooks.ps1``` script. 
+To exclude tasks from validation, go to ```View -> Cell Toolbar -> Tags``` to see the cells that have been tagged and/or to add a new tag to a cell. If there is a new reason for some tasks to be excluded from validation, feel free to update the [exclude_from_validation set](https://github.com/microsoft/QuantumKatas/blob/main/scripts/validate-notebooks.ps1#L91) in ```validate-notebooks.ps1``` script and add an explaination for the new cell tag in ```validate-notebooks.ps1``` script and this contribution guide as well.
 
 PS : After adding the tags to the jupyter notebook, please do ```View -> Cell Toolbar -> None``` and save your changes through ```Ctrl+S``` or by hitting ```Save and Checkpoint``` button. This is necessary because we don't want learner to see the cell tags associated with each cell when they open the jupyter notebook.
 

--- a/CHSHGame/CHSHGame.ipynb
+++ b/CHSHGame/CHSHGame.ipynb
@@ -89,7 +89,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "two_player_game"
+    ]
+   },
    "outputs": [],
    "source": [
     "%kata T12_ClassicalStrategy \n",
@@ -112,7 +116,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "two_player_game"
+    ]
+   },
    "outputs": [],
    "source": [
     "%kata T12_ClassicalStrategy \n",

--- a/CHSHGame/CHSHGame.ipynb
+++ b/CHSHGame/CHSHGame.ipynb
@@ -317,7 +317,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "failure_of_correct_solution"
+    ]
+   },
    "outputs": [],
    "source": [
     "%kata T25_PlayQuantumCHSH \n",

--- a/CHSHGame/CHSHGame.ipynb
+++ b/CHSHGame/CHSHGame.ipynb
@@ -91,7 +91,7 @@
    "execution_count": null,
    "metadata": {
     "tags": [
-     "two_player_game"
+     "multicell_solution"
     ]
    },
    "outputs": [],
@@ -118,7 +118,7 @@
    "execution_count": null,
    "metadata": {
     "tags": [
-     "two_player_game"
+     "multicell_solution"
     ]
    },
    "outputs": [],
@@ -319,7 +319,7 @@
    "execution_count": null,
    "metadata": {
     "tags": [
-     "failure_of_correct_solution"
+     "randomized_solution"
     ]
    },
    "outputs": [],

--- a/CHSHGame/CHSHGame.ipynb
+++ b/CHSHGame/CHSHGame.ipynb
@@ -319,7 +319,7 @@
    "execution_count": null,
    "metadata": {
     "tags": [
-     "randomized_solution"
+     "multicell_solution"
     ]
    },
    "outputs": [],

--- a/CHSHGame/Tests.qs
+++ b/CHSHGame/Tests.qs
@@ -159,6 +159,6 @@ namespace Quantum.Kata.CHSHGame {
                 set wins = wins + 1;
             }
         }
-        EqualityWithinToleranceFact(IntAsDouble(wins) / 10000., 0.85, 0.9);
+        EqualityWithinToleranceFact(IntAsDouble(wins) / 10000., 0.85, 0.01);
     }
 }

--- a/CHSHGame/Tests.qs
+++ b/CHSHGame/Tests.qs
@@ -159,6 +159,6 @@ namespace Quantum.Kata.CHSHGame {
                 set wins = wins + 1;
             }
         }
-        EqualityWithinToleranceFact(IntAsDouble(wins) / 10000., 0.85, 0.5);
+        EqualityWithinToleranceFact(IntAsDouble(wins) / 10000., 0.85, 0.9);
     }
 }

--- a/CHSHGame/Tests.qs
+++ b/CHSHGame/Tests.qs
@@ -159,6 +159,6 @@ namespace Quantum.Kata.CHSHGame {
                 set wins = wins + 1;
             }
         }
-        EqualityWithinToleranceFact(IntAsDouble(wins) / 10000., 0.85, 0.01);
+        EqualityWithinToleranceFact(IntAsDouble(wins) / 10000., 0.85, 0.1);
     }
 }

--- a/CHSHGame/Workbook_CHSHGame.ipynb
+++ b/CHSHGame/Workbook_CHSHGame.ipynb
@@ -412,7 +412,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "failure_of_correct_solution"
+    ]
+   },
    "outputs": [],
    "source": [
     "%kata T25_PlayQuantumCHSH \n",

--- a/CHSHGame/Workbook_CHSHGame.ipynb
+++ b/CHSHGame/Workbook_CHSHGame.ipynb
@@ -106,7 +106,7 @@
    "execution_count": null,
    "metadata": {
     "tags": [
-     "two_player_game"
+     "multicell_solution"
     ]
    },
    "outputs": [],
@@ -123,7 +123,7 @@
    "execution_count": null,
    "metadata": {
     "tags": [
-     "two_player_game"
+     "multicell_solution"
     ]
    },
    "outputs": [],
@@ -414,7 +414,7 @@
    "execution_count": null,
    "metadata": {
     "tags": [
-     "failure_of_correct_solution"
+     "randomized_solution"
     ]
    },
    "outputs": [],

--- a/CHSHGame/Workbook_CHSHGame.ipynb
+++ b/CHSHGame/Workbook_CHSHGame.ipynb
@@ -104,7 +104,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "two_player_game"
+    ]
+   },
    "outputs": [],
    "source": [
     "%kata T12_ClassicalStrategy \n",
@@ -117,7 +121,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "two_player_game"
+    ]
+   },
    "outputs": [],
    "source": [
     "%kata T12_ClassicalStrategy \n",

--- a/CHSHGame/Workbook_CHSHGame.ipynb
+++ b/CHSHGame/Workbook_CHSHGame.ipynb
@@ -414,7 +414,7 @@
    "execution_count": null,
    "metadata": {
     "tags": [
-     "randomized_solution"
+     "multicell_solution"
     ]
    },
    "outputs": [],

--- a/GraphColoring/GraphColoring.ipynb
+++ b/GraphColoring/GraphColoring.ipynb
@@ -348,7 +348,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "timeout"
+    ]
+   },
    "outputs": [],
    "source": [
     "%kata T23_GroversAlgorithm \n",

--- a/GraphColoring/Workbook_GraphColoring.ipynb
+++ b/GraphColoring/Workbook_GraphColoring.ipynb
@@ -633,7 +633,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "timeout"
+    ]
+   },
    "outputs": [],
    "source": [
     "%kata T23_GroversAlgorithm \n",

--- a/MagicSquareGame/MagicSquareGame.ipynb
+++ b/MagicSquareGame/MagicSquareGame.ipynb
@@ -584,7 +584,6 @@
   }
  ],
  "metadata": {
-  "celltoolbar": "Tags",
   "kernelspec": {
    "display_name": "Q#",
    "language": "qsharp",

--- a/MagicSquareGame/MagicSquareGame.ipynb
+++ b/MagicSquareGame/MagicSquareGame.ipynb
@@ -60,7 +60,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "two_player_game"
+    ]
+   },
    "outputs": [],
    "source": [
     "%kata T11_ValidMove \n",
@@ -87,7 +91,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "two_player_game"
+    ]
+   },
    "outputs": [],
    "source": [
     "%kata T11_ValidMove \n",
@@ -151,7 +159,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "two_player_game"
+    ]
+   },
    "outputs": [],
    "source": [
     "%kata T13_ClassicalStrategy \n",
@@ -177,7 +189,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "two_player_game"
+    ]
+   },
    "outputs": [],
    "source": [
     "%kata T13_ClassicalStrategy \n",
@@ -556,6 +572,7 @@
   }
  ],
  "metadata": {
+  "celltoolbar": "Tags",
   "kernelspec": {
    "display_name": "Q#",
    "language": "qsharp",
@@ -565,7 +582,7 @@
    "file_extension": ".qs",
    "mimetype": "text/x-qsharp",
    "name": "qsharp",
-   "version": "0.4"
+   "version": "0.12"
   }
  },
  "nbformat": 4,

--- a/MagicSquareGame/MagicSquareGame.ipynb
+++ b/MagicSquareGame/MagicSquareGame.ipynb
@@ -62,7 +62,7 @@
    "execution_count": null,
    "metadata": {
     "tags": [
-     "two_player_game"
+     "multicell_solution"
     ]
    },
    "outputs": [],
@@ -93,7 +93,7 @@
    "execution_count": null,
    "metadata": {
     "tags": [
-     "two_player_game"
+     "multicell_solution"
     ]
    },
    "outputs": [],
@@ -161,7 +161,7 @@
    "execution_count": null,
    "metadata": {
     "tags": [
-     "two_player_game"
+     "multicell_solution"
     ]
    },
    "outputs": [],
@@ -191,7 +191,7 @@
    "execution_count": null,
    "metadata": {
     "tags": [
-     "two_player_game"
+     "multicell_solution"
     ]
    },
    "outputs": [],
@@ -445,7 +445,7 @@
    "execution_count": null,
    "metadata": {
     "tags": [
-     "two_player_game"
+     "multicell_solution"
     ]
    },
    "outputs": [],
@@ -479,7 +479,7 @@
    "execution_count": null,
    "metadata": {
     "tags": [
-     "two_player_game"
+     "multicell_solution"
     ]
    },
    "outputs": [],
@@ -516,7 +516,7 @@
    "execution_count": null,
    "metadata": {
     "tags": [
-     "failure_of_correct_solution"
+     "randomized_solution"
     ]
    },
    "outputs": [],

--- a/MagicSquareGame/MagicSquareGame.ipynb
+++ b/MagicSquareGame/MagicSquareGame.ipynb
@@ -443,7 +443,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "two_player_game"
+    ]
+   },
    "outputs": [],
    "source": [
     "%kata T26_QuantumStrategy \n",
@@ -473,7 +477,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "two_player_game"
+    ]
+   },
    "outputs": [],
    "source": [
     "%kata T26_QuantumStrategy \n",

--- a/MagicSquareGame/MagicSquareGame.ipynb
+++ b/MagicSquareGame/MagicSquareGame.ipynb
@@ -516,7 +516,7 @@
    "execution_count": null,
    "metadata": {
     "tags": [
-     "randomized_solution"
+     "multicell_solution"
     ]
    },
    "outputs": [],
@@ -557,7 +557,7 @@
     "</details>\n",
     "<br/>\n",
     "<details>\n",
-    "  <summary>Need another hint? Click here</summary>\n",
+    "  <summary><b>Need another hint? Click here</b></summary>\n",
     "    Use <code>WinCondition</code> function from task 1.2 to check that Alice and Bob won the game.\n",
     "</details>"
    ]

--- a/MagicSquareGame/MagicSquareGame.ipynb
+++ b/MagicSquareGame/MagicSquareGame.ipynb
@@ -514,7 +514,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "failure_of_correct_solution"
+    ]
+   },
    "outputs": [],
    "source": [
     "%kata T27_PlayQuantumMagicSquare \n",

--- a/SolveSATWithGrover/SolveSATWithGrover.ipynb
+++ b/SolveSATWithGrover/SolveSATWithGrover.ipynb
@@ -537,7 +537,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "timeout"
+    ]
+   },
    "outputs": [],
    "source": [
     "%kata T32_UniversalGroversAlgorithm \n",

--- a/SolveSATWithGrover/Workbook_SolveSATWithGrover.ipynb
+++ b/SolveSATWithGrover/Workbook_SolveSATWithGrover.ipynb
@@ -1019,7 +1019,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "timeout"
+    ]
+   },
    "outputs": [],
    "source": [
     "%kata T32_UniversalGroversAlgorithm \n",

--- a/scripts/validate-notebooks.ps1
+++ b/scripts/validate-notebooks.ps1
@@ -83,16 +83,24 @@ function Validate {
             </configuration>
         " | Out-File ./NuGet.Config -Encoding utf8
 
+		# Specifying tasks that need to be excluded because of various reasons :
+		# two_player_game : These tasks require implementing two code cells at once before running the test, so the first of the cells implemented is guaranteed to fail.
+		# failure_of_correct_solution : Tasks for which the correct solution fails with relatively high probability.
+		# timeout : Tasks for which the correct solution times out with relatively high probability.
+		# invalid_code : Tasks with deliberately invalid code
+		# work_in_progress : If the solutions to the tasks(Either in ReferenceImplementation or Workbook) are work_in_progress
+		$exclude_from_validation = "['two_player_game', 'failure_of_correct_solution', 'timeout', 'invalid_code', 'work_in_progress']"
+
         # Run Jupyter nbconvert to execute the kata.
         # dotnet-iqsharp writes some output to stderr, which causes PowerShell to throw
         # unless $ErrorActionPreference is set to 'Continue'.
         $ErrorActionPreference = 'Continue'
         if ($env:SYSTEM_DEBUG -eq "true") {
             # Redirect stderr output to stdout to prevent an exception being incorrectly thrown.
-            jupyter nbconvert $CheckNotebook --execute --to html --ExecutePreprocessor.timeout=300 --log-level=DEBUG 2>&1 | %{ "$_"}
+            jupyter nbconvert $CheckNotebook --TagRemovePreprocessor.remove_cell_tags=$exclude_from_validation  --execute --to html --ExecutePreprocessor.timeout=300 --log-level=DEBUG 2>&1 | %{ "$_"}
         } else {
             # Redirect stderr output to stdout to prevent an exception being incorrectly thrown.
-            jupyter nbconvert $CheckNotebook --execute --to html --ExecutePreprocessor.timeout=300 2>&1 | %{ "$_"}
+            jupyter nbconvert $CheckNotebook --TagRemovePreprocessor.remove_cell_tags=$exclude_from_validation --execute --to html --ExecutePreprocessor.timeout=300 2>&1 | %{ "$_"}
         }
         $ErrorActionPreference = 'Stop'
 

--- a/scripts/validate-notebooks.ps1
+++ b/scripts/validate-notebooks.ps1
@@ -132,8 +132,6 @@ function Validate {
 $not_ready = 
 @(
     'Check.ipynb',
-    'CHSHGame.ipynb',
-    'Workbook_CHSHGame.ipynb',
     'GraphColoring.ipynb',
     'Workbook_GraphColoring.ipynb',
     'MagicSquareGame.ipynb',

--- a/scripts/validate-notebooks.ps1
+++ b/scripts/validate-notebooks.ps1
@@ -122,23 +122,12 @@ function Validate {
 
 # List of Notebooks that can't be validated for various reasons:
 #  * Check.ipynb is a validation artifact and not an actual kata notebook.
-#  * CHSH and MagicSquare games require implementing two code cells at once before running the test, 
-#    so the first of the cells implemented is guaranteed to fail.
-#  * GraphColoring and SolveSATWithGrover (and its Workbook) have tasks for which the correct solution fails or times out with relatively high probability.
-#  * ExploringGroversAlgorithm has tasks with deliberately invalid Q# code.
 #  * ComplexArithmetic and LinearAlgebra have tasks with deliberately invalid Python code.
 #  * RandomNumberGenerationTutorial have tasks to generate random numbers but if it is run a lot of times then randomly generated numbers will look insufficiently random
 #
 $not_ready = 
 @(
     'Check.ipynb',
-    'GraphColoring.ipynb',
-    'Workbook_GraphColoring.ipynb',
-    'MagicSquareGame.ipynb',
-    'SolveSATWithGrover.ipynb',
-    'Workbook_SolveSATWithGrover.ipynb',
-    'ExploringGroversAlgorithmTutorial.ipynb',
-    'VisualizingGroversAlgorithm.ipynb',
     'ComplexArithmetic.ipynb',
     'LinearAlgebra.ipynb',
 	'RandomNumberGenerationTutorial.ipynb'

--- a/scripts/validate-notebooks.ps1
+++ b/scripts/validate-notebooks.ps1
@@ -83,13 +83,12 @@ function Validate {
             </configuration>
         " | Out-File ./NuGet.Config -Encoding utf8
 
-        # Specifying tasks that need to be excluded because of various reasons :
-        # two_player_game : These tasks require implementing two code cells at once before running the test, so the first of the cells implemented is guaranteed to fail.
-        # failure_of_correct_solution : Tasks for which the correct solution fails with relatively high probability.
+        # See the explaination for excluding tasks in Contribution guide at https://github.com/microsoft/QuantumKatas/blob/main/.github/CONTRIBUTING.md/#L93
+        # multicell_solution : These tasks require implementing two code cells at once before running the test, so the first of the cells implemented is guaranteed to fail.
+        # randomized_solution : Tasks for which the correct solution fails with relatively high probability.
         # timeout : Tasks for which the correct solution times out with relatively high probability.
         # invalid_code : Tasks with deliberately invalid code
-        # work_in_progress : If the solutions to the tasks(Either in ReferenceImplementation or Workbook) are work_in_progress
-        $exclude_from_validation = "['two_player_game', 'failure_of_correct_solution', 'timeout', 'invalid_code', 'work_in_progress']"
+        $exclude_from_validation = "['multicell_solution', 'randomized_solution', 'timeout', 'invalid_code', 'work_in_progress']"
 
         # Run Jupyter nbconvert to execute the kata.
         # dotnet-iqsharp writes some output to stderr, which causes PowerShell to throw

--- a/scripts/validate-notebooks.ps1
+++ b/scripts/validate-notebooks.ps1
@@ -119,7 +119,8 @@ function Validate {
 #  * GraphColoring and SolveSATWithGrover (and its Workbook) have tasks for which the correct solution fails or times out with relatively high probability.
 #  * ExploringGroversAlgorithm has tasks with deliberately invalid Q# code.
 #  * ComplexArithmetic and LinearAlgebra have tasks with deliberately invalid Python code.
-# 
+#  * RandomNumberGenerationTutorial have tasks to generate random numbers but if it is run a lot of times then randomly generated numbers will look insufficiently random
+#
 $not_ready = 
 @(
     'Check.ipynb',
@@ -133,7 +134,8 @@ $not_ready =
     'ExploringGroversAlgorithmTutorial.ipynb',
     'VisualizingGroversAlgorithm.ipynb',
     'ComplexArithmetic.ipynb',
-    'LinearAlgebra.ipynb'
+    'LinearAlgebra.ipynb',
+	'RandomNumberGenerationTutorial.ipynb'
 )
 
 

--- a/scripts/validate-notebooks.ps1
+++ b/scripts/validate-notebooks.ps1
@@ -83,11 +83,8 @@ function Validate {
             </configuration>
         " | Out-File ./NuGet.Config -Encoding utf8
 
-        # See the explaination for excluding tasks in Contribution guide at https://github.com/microsoft/QuantumKatas/blob/main/.github/CONTRIBUTING.md/#L93
-        # multicell_solution : These tasks require implementing two code cells at once before running the test, so the first of the cells implemented is guaranteed to fail.
-        # randomized_solution : Tasks for which the correct solution fails with relatively high probability.
-        # timeout : Tasks for which the correct solution times out with relatively high probability.
-        # invalid_code : Tasks with deliberately invalid code
+        # See the explanation for excluding individual tasks in Contribution guide at 
+        # https://github.com/microsoft/QuantumKatas/blob/main/.github/CONTRIBUTING.md#excluding-individual-tasks-from-validation
         $exclude_from_validation = "['multicell_solution', 'randomized_solution', 'timeout', 'invalid_code', 'work_in_progress']"
 
         # Run Jupyter nbconvert to execute the kata.
@@ -103,7 +100,7 @@ function Validate {
         }
         $ErrorActionPreference = 'Stop'
 
-        # if jupyter returns an error code, report that this notebook is invalid:
+        # if Jupyter returns an error code, report that this notebook is invalid:
         if ($LastExitCode -ne 0) {
             Write-Host "##vso[task.logissue type=error;]Validation errors for $Notebook ."        
             $script:all_ok = $false
@@ -122,8 +119,7 @@ function Validate {
 # List of Notebooks that can't be validated for various reasons:
 #  * Check.ipynb is a validation artifact and not an actual kata notebook.
 #  * ComplexArithmetic and LinearAlgebra have tasks with deliberately invalid Python code.
-#  * RandomNumberGenerationTutorial have tasks to generate random numbers but if it is run a lot of times then randomly generated numbers will look insufficiently random
-#
+#  * RandomNumberGenerationTutorial have tasks to generate random numbers but sometimes these numbers will look insufficiently random and fail validation.
 $not_ready = 
 @(
     'Check.ipynb',

--- a/scripts/validate-notebooks.ps1
+++ b/scripts/validate-notebooks.ps1
@@ -83,13 +83,13 @@ function Validate {
             </configuration>
         " | Out-File ./NuGet.Config -Encoding utf8
 
-		# Specifying tasks that need to be excluded because of various reasons :
-		# two_player_game : These tasks require implementing two code cells at once before running the test, so the first of the cells implemented is guaranteed to fail.
-		# failure_of_correct_solution : Tasks for which the correct solution fails with relatively high probability.
-		# timeout : Tasks for which the correct solution times out with relatively high probability.
-		# invalid_code : Tasks with deliberately invalid code
-		# work_in_progress : If the solutions to the tasks(Either in ReferenceImplementation or Workbook) are work_in_progress
-		$exclude_from_validation = "['two_player_game', 'failure_of_correct_solution', 'timeout', 'invalid_code', 'work_in_progress']"
+        # Specifying tasks that need to be excluded because of various reasons :
+        # two_player_game : These tasks require implementing two code cells at once before running the test, so the first of the cells implemented is guaranteed to fail.
+        # failure_of_correct_solution : Tasks for which the correct solution fails with relatively high probability.
+        # timeout : Tasks for which the correct solution times out with relatively high probability.
+        # invalid_code : Tasks with deliberately invalid code
+        # work_in_progress : If the solutions to the tasks(Either in ReferenceImplementation or Workbook) are work_in_progress
+        $exclude_from_validation = "['two_player_game', 'failure_of_correct_solution', 'timeout', 'invalid_code', 'work_in_progress']"
 
         # Run Jupyter nbconvert to execute the kata.
         # dotnet-iqsharp writes some output to stderr, which causes PowerShell to throw
@@ -130,7 +130,7 @@ $not_ready =
     'Check.ipynb',
     'ComplexArithmetic.ipynb',
     'LinearAlgebra.ipynb',
-	'RandomNumberGenerationTutorial.ipynb'
+    'RandomNumberGenerationTutorial.ipynb'
 )
 
 

--- a/tutorials/ExploringGroversAlgorithm/ExploringGroversAlgorithmTutorial.ipynb
+++ b/tutorials/ExploringGroversAlgorithm/ExploringGroversAlgorithmTutorial.ipynb
@@ -270,7 +270,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "invalid_code"
+    ]
+   },
    "outputs": [],
    "source": [
     "open Microsoft.Quantum.Convert;\n",
@@ -324,7 +328,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "invalid_code"
+    ]
+   },
    "outputs": [],
    "source": [
     "%simulate RunGroversAlgorithm_OutputVerification"

--- a/tutorials/ExploringGroversAlgorithm/ExploringGroversAlgorithmTutorial.ipynb
+++ b/tutorials/ExploringGroversAlgorithm/ExploringGroversAlgorithmTutorial.ipynb
@@ -373,7 +373,7 @@
    "execution_count": null,
    "metadata": {
     "tags": [
-     "timeout"
+     "invalid_code"
     ]
    },
    "outputs": [],
@@ -421,7 +421,7 @@
    "execution_count": null,
    "metadata": {
     "tags": [
-     "timeout"
+     "invalid_code"
     ]
    },
    "outputs": [],
@@ -487,7 +487,7 @@
    "execution_count": null,
    "metadata": {
     "tags": [
-     "timeout"
+     "invalid_code"
     ]
    },
    "outputs": [],
@@ -537,7 +537,7 @@
    "execution_count": null,
    "metadata": {
     "tags": [
-     "timeout"
+     "invalid_code"
     ]
    },
    "outputs": [],

--- a/tutorials/ExploringGroversAlgorithm/ExploringGroversAlgorithmTutorial.ipynb
+++ b/tutorials/ExploringGroversAlgorithm/ExploringGroversAlgorithmTutorial.ipynb
@@ -371,7 +371,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "timeout"
+    ]
+   },
    "outputs": [],
    "source": [
     "open Microsoft.Quantum.Convert;\n",
@@ -415,7 +419,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "timeout"
+    ]
+   },
    "outputs": [],
    "source": [
     "%simulate RunGroversAlgorithm_RerunIncorrectAnswer"
@@ -477,7 +485,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "timeout"
+    ]
+   },
    "outputs": [],
    "source": [
     "open Microsoft.Quantum.Convert;\n",
@@ -523,7 +535,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "timeout"
+    ]
+   },
    "outputs": [],
    "source": [
     "%simulate RunGroversAlgorithm_CalculateSuccessProbability"


### PR DESCRIPTION
Currently <code>validate-notebooks.ps1</code> script excludes several notebooks in which some tasks would fail validation due to several reasons : 
- Some tasks require implementing two code cells at once before running the test, so the first of the cells implemented is guaranteed to fail
-  There are some tasks for which the correct solution fails with relatively high probability or correct solution times out with relatively high probability
- There are some tasks with deliberately invalid code
- If the solutions to the tasks(Either in ReferenceImplementation or Workbook) are work_in_progress 
This PR aims to identify those tasks and exclude them.  See https://github.com/microsoft/QuantumKatas/issues/485 for more details.

@tcNickolas, I made a small change to the implementation as discussed in https://github.com/microsoft/QuantumKatas/issues/485. Instead of excluding tasks which need to be excluded from validation using <code>exclude_from_validation</code> tag; I have specified a <code>$exclude_from_validation </code> set to specify the set of cell tags which would be excluded from validation so that its easy for the contributors to know why the specific task is being excluded from validation <code>$exclude_from_validation = "['two_player_game', 'failure_of_correct_solution', 'timeout', 'invalid_code', 'work_in_progress']" </code>. And then I exclude all cell tags in <code>$exclude_from_validation </code> set by  <code>$CheckNotebook --TagRemovePreprocessor.remove_cell_tags=$exclude_from_validation</code>