### PR TITLE
Fixing Pauli Gates ZX operation result typo

### DIFF
--- a/tutorials/SingleQubitGates/SingleQubitGates.ipynb
+++ b/tutorials/SingleQubitGates/SingleQubitGates.ipynb
@@ -331,7 +331,7 @@
     "* Different Pauli gates *anti-commute*:\n",
     "  $$XZ = -ZX, XY = -YX, YZ = -ZY$$\n",
     "* A product of any two Pauli gates equals the third gate, with an extra $i$ (or $-i$) phase:\n",
-    "  $$XY = iZ, YZ = iX, ZX = -Y$$\n",
+    "  $$XY = iZ, YZ = iX, ZX = iY$$\n",
     "* A product of all three Pauli gates equals identity (with an extra $i$ phase):\n",
     "  $$XYZ = iI$$"
    ]


### PR DESCRIPTION
Typo in ZX = -Y, as ZX = iY (as stated in the previous instruction):
ZX = [[1, 0], [0, -1]] [[0, 1], [1, 0]] = [[0, 1],[-1, 0]] = i [[0, -i], [i, 0]] = iY