### PR TITLE
Hint fix in the measurements Kata

### DIFF
--- a/Measurements/Measurements.ipynb
+++ b/Measurements/Measurements.ipynb
@@ -674,13 +674,7 @@
     "\n",
     "The state of the qubit at the end of the operation does not matter.\n",
     "\n",
-    "> This task is an example of unambiguous state discrimination.\n",
-    "\n",
-    "<br/>\n",
-    "<details>\n",
-    "  <summary><b>Need a hint? Click here</b></summary>\n",
-    "  You can use extra qubit(s) is your solution.\n",
-    "</details>"
+    "> This task is an example of unambiguous state discrimination.\n"
    ]
   },
   {
@@ -725,7 +719,13 @@
     "\n",
     "You are never allowed to give an incorrect answer. Your solution will be called multiple times, with one of the states picked with equal probability every time.\n",
     "\n",
-    "The state of the qubit at the end of the operation does not matter. "
+    "The state of the qubit at the end of the operation does not matter. ",
+    "\n",
+    "<br/>\n",
+    "<details>\n",
+    "  <summary><b>Need a hint? Click here</b></summary>\n",
+    "  You can use extra qubit(s) in your solution.\n",
+    "</details>"
    ]
   },
   {

--- a/Measurements/Tasks.qs
+++ b/Measurements/Tasks.qs
@@ -314,7 +314,6 @@ namespace Quantum.Kata.Measurements {
     //  - must correctly identify |+⟩ state as 1 in at least 10% of the cases.
     //
     // The state of the qubit at the end of the operation does not matter.
-    // You are allowed to use ancilla qubit(s).
     operation IsQubitPlusZeroOrInconclusiveSimpleUSD (q : Qubit) : Int {
         // ...
         return -2;
@@ -332,6 +331,7 @@ namespace Quantum.Kata.Measurements {
     //         0 or 2 if the qubit was in the |B⟩ state,
     //         0 or 1 if the qubit was in the |C⟩ state.
     // The state of the qubit at the end of the operation does not matter.
+    // You can use extra qubit(s) in your solution.
     // Note: in this task you have to succeed with probability 1, i.e., you are never allowed
     //       to give an incorrect answer.
     operation IsQubitNotInABC (q : Qubit) : Int {


### PR DESCRIPTION
Moved the hint about an extra qubit to the right Kata: "Task 2.3**. Peres/Wooters game". "Task 2.2**.  |0⟩ ,  |+⟩  or inconclusive" doesn't need an extra qubit. Fixed a typo.