### PR TITLE
Switch from CounterSimulator.GetMaxQubitCount to AllowAtMostNQubits (#544)

### DIFF
--- a/GraphColoring/Tasks.qs
+++ b/GraphColoring/Tasks.qs
@@ -6,6 +6,7 @@ namespace Quantum.Kata.GraphColoring {
     open Microsoft.Quantum.Diagnostics;
     open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Canon;
+    open Microsoft.Quantum.Arrays;
 
     //////////////////////////////////////////////////////////////////
     // Welcome!

--- a/GraphColoring/Tests.qs
+++ b/GraphColoring/Tests.qs
@@ -139,7 +139,7 @@ namespace Quantum.Kata.GraphColoring {
     operation T15_ColorEqualityOracle_Nbit () : Unit {
         for (N in 1..4) {            
             within {
-                AllowAtMostNQubits(2*N+1, "You are not allowed to allocate extra qubits.");
+                AllowAtMostNQubits(2*N+1, "You are not allowed to allocate extra qubits");
             } apply {
                 CheckColorEqualityOracle(N, ColorEqualityOracle_Nbit);
             }

--- a/GraphColoring/Tests.qs
+++ b/GraphColoring/Tests.qs
@@ -135,15 +135,14 @@ namespace Quantum.Kata.GraphColoring {
 
 
     // ------------------------------------------------------
-    @Test("Microsoft.Quantum.Katas.CounterSimulator")
+    @Test("QuantumSimulator")
     operation T15_ColorEqualityOracle_Nbit () : Unit {
-        for (N in 1..4) {
-            ResetQubitCount();
-            
-            CheckColorEqualityOracle(N, ColorEqualityOracle_Nbit);
-
-            let nq = GetMaxQubitCount();
-            EqualityFactI(nq, 2*N+1, $"You are not allowed to allocate extra qubits. You allocated {nq - (2*N+1)}");
+        for (N in 1..4) {            
+            within {
+                AllowAtMostNQubits(2*N+1, "You are not allowed to allocate extra qubits.");
+            } apply {
+                CheckColorEqualityOracle(N, ColorEqualityOracle_Nbit);
+            }
 
             AssertOperationsEqualReferenced(2*N+1, WrapperOperation(ColorEqualityOracle_Nbit, _),
                                                    WrapperOperation(ColorEqualityOracle_Nbit_Reference, _));

--- a/PhaseEstimation/Tasks.qs
+++ b/PhaseEstimation/Tasks.qs
@@ -8,6 +8,7 @@ namespace Quantum.Kata.PhaseEstimation {
     open Microsoft.Quantum.Diagnostics;
     open Microsoft.Quantum.Convert;
     open Microsoft.Quantum.Math;
+    open Microsoft.Quantum.Measurement;
 
     
     //////////////////////////////////////////////////////////////////

--- a/PhaseEstimation/Tests.qs
+++ b/PhaseEstimation/Tests.qs
@@ -87,14 +87,14 @@ namespace Quantum.Kata.PhaseEstimation {
     //////////////////////////////////////////////////////////////////
     
     operation Test1BitPEOnOnePair(U : (Qubit => Unit is Adj + Ctl), P : (Qubit => Unit is Adj), expected : Int) : Unit {
-        ResetQubitCount();
         ResetOracleCallsCount();
 
-        let actual = SingleBitPE(U, P);
-        EqualityFactI(actual, expected, $"Unexpected return for ({U}, {P}): expected {expected}, got {actual}");
-        
-        let nq = GetMaxQubitCount();
-        EqualityFactI(nq, 2, $"You are allowed to allocate exactly 2 qubits, and you allocated {nq}");
+        within {
+            AllowAtMostNQubits(2, "You are allowed to allocate exactly 2 qubits");
+        } apply {
+            let actual = SingleBitPE(U, P);
+            EqualityFactI(actual, expected, $"Unexpected return for ({U}, {P}): expected {expected}, got {actual}");
+        }
         
         let nu = GetOracleCallsCount(Controlled U);
         EqualityFactI(nu, 1, $"You are allowed to call Controlled U exactly once, and you called it {nu} times");
@@ -111,16 +111,15 @@ namespace Quantum.Kata.PhaseEstimation {
 
     // ------------------------------------------------------
     operation Test2BitPEOnOnePair(U : (Qubit => Unit is Adj + Ctl), P : (Qubit => Unit is Adj), expected : Double) : Unit {
-        ResetQubitCount();
-
-        let actual = TwoBitPE(U, P);
-        EqualityWithinToleranceFact(actual, expected, 0.001);
-        
-        let nq = GetMaxQubitCount();
-        EqualityFactI(nq, 2, $"You are allowed to allocate exactly 2 qubits, and you allocated {nq}");
+        within {
+            AllowAtMostNQubits(2, "You are allowed to allocate exactly 2 qubits");
+        } apply {
+            let actual = TwoBitPE(U, P);
+            EqualityWithinToleranceFact(actual, expected, 0.001);
+        }
     }
 
-    @Test("Microsoft.Quantum.Katas.CounterSimulator")
+    @Test("QuantumSimulator")
     operation T22_TwoBitPE () : Unit {
         Test2BitPEOnOnePair(Z, I, 0.0);
         Test2BitPEOnOnePair(Z, X, 0.5);

--- a/RippleCarryAdder/Tests.qs
+++ b/RippleCarryAdder/Tests.qs
@@ -391,18 +391,19 @@ namespace Quantum.Kata.RippleCarryAdder {
     }
 
     // ------------------------------------------------------
-    @Test("Microsoft.Quantum.Katas.CounterSimulator")
+    @Test("QuantumSimulator")
     operation T35_ArbitraryMajUmaAdder () : Unit {
         // This algorithm is much faster, so a 5 qubit test is feasible
         for (i in 1 .. 5) {
             let testOp = QubitArrayInPlaceAdderWrapper(i, ArbitraryMajUmaAdder, _);
             let refOp = QubitArrayInPlaceAdderWrapper(i, ArbitraryMajUmaAdder_Reference, _);
 
-            ResetQubitCount();
-            AssertInPlaceOperationImplementsBinaryFunction(testOp, BinaryAdder(_, i), 2 * i, i, (2 * i) - 1, 1);
-            let used = GetMaxQubitCount();
-            Fact(used <= (2 * (i + 1)), "Too many qubits used");
-            
+             within {
+                AllowAtMostNQubits(2 * (i + 1), "Too many qubits used");
+            } apply {
+                AssertInPlaceOperationImplementsBinaryFunction(testOp, BinaryAdder(_, i), 2 * i, i, (2 * i) - 1, 1);
+            }
+           
             AssertOperationsEqualReferenced((2 * i) + 1, testOp, refOp);
         }
     }


### PR DESCRIPTION
Using AllowAtMostNQubits we are able to replace the usage of the QuantumCounter in some tasks to use the basic QuantumSimulator. 
Related issue: https://github.com/microsoft/QuantumKatas/issues/544

### Major changes 
**Affected Tasks**
 GraphColoring, task 1.5
 RippleCarryAdder, task 3.5
 PhaseEstimation, tasks 2.1 and 2.2

Note: at first we wanted also replace AllowAtMostNCallsCA instead of GetOracleCallsCount in task 2.1, but I found a bug in AllowAtMostNCallsCA where a controlled unitary is considered the same as its non-controlled variant. 
ref: https://github.com/microsoft/QuantumLibraries/issues/367

When this bug will get fix, we will be able to replace GetOracleCallsCount  by AllowAtMostNCallsCA  in bulk wherever it is used. 

### Minor changes
GraphColoring/Tasks.qs: added import from open Microsoft.Quantum.Arrays;. Current reference implementation needs it.
PhaseEstimation/Tasks.qs: added import from   Microsoft.Quantum.Measurement. Current reference implementation needs it.

### Testing

1. Apply change in test.qs
2. Copy reference implementation in task.qs
3. dotnet test: Verify that the test pass
4. Modify implementation in task.qs to allocate one more qubit
5. dotnet test: Verify that the test fails with correct error output. 
