### PR TITLE
Update Quantum SDK references to enable local e2e builds after compiler breaking change

### DIFF
--- a/BasicGates/BasicGates.csproj
+++ b/BasicGates/BasicGates.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20102604">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20111102-beta">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Katas" Version="0.13.20102604" />
-    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.13.20102604" />
+    <PackageReference Include="Microsoft.Quantum.Katas" Version="0.13.20111102-beta" />
+    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.13.20111102-beta" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/CHSHGame/CHSHGame.csproj
+++ b/CHSHGame/CHSHGame.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20102604">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20111102-beta">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>  
-    <PackageReference Include="Microsoft.Quantum.Katas" Version="0.13.20102604" />
-    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.13.20102604" />
+    <PackageReference Include="Microsoft.Quantum.Katas" Version="0.13.20111102-beta" />
+    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.13.20111102-beta" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/DeutschJozsaAlgorithm/DeutschJozsaAlgorithm.csproj
+++ b/DeutschJozsaAlgorithm/DeutschJozsaAlgorithm.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20102604">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20111102-beta">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
@@ -7,8 +7,8 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Katas" Version="0.13.20102604" />
-    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.13.20102604" />
+    <PackageReference Include="Microsoft.Quantum.Katas" Version="0.13.20111102-beta" />
+    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.13.20111102-beta" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/DistinguishUnitaries/DistinguishUnitaries.csproj
+++ b/DistinguishUnitaries/DistinguishUnitaries.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20102604">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20111102-beta">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Katas" Version="0.13.20102604" />
-    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.13.20102604" />
+    <PackageReference Include="Microsoft.Quantum.Katas" Version="0.13.20111102-beta" />
+    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.13.20111102-beta" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # We use the iqsharp-base image, as that includes
 # the .NET Core SDK, IQ#, and Jupyter Notebook already
 # installed for us.
-FROM mcr.microsoft.com/quantum/iqsharp-base:0.13.20102604
+FROM mcr.microsoft.com/quantum/iqsharp-base:0.13.20111102-beta
 
 # Add metadata indicating that this image is used for the katas.
 ENV IQSHARP_HOSTING_ENV=KATAS_DOCKERFILE

--- a/GHZGame/GHZGame.csproj
+++ b/GHZGame/GHZGame.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20102604">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20111102-beta">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Katas" Version="0.13.20102604" />
-    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.13.20102604" />
+    <PackageReference Include="Microsoft.Quantum.Katas" Version="0.13.20111102-beta" />
+    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.13.20111102-beta" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/GraphColoring/GraphColoring.csproj
+++ b/GraphColoring/GraphColoring.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20102604">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20111102-beta">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Katas" Version="0.13.20102604" />
-    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.13.20102604" />
+    <PackageReference Include="Microsoft.Quantum.Katas" Version="0.13.20111102-beta" />
+    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.13.20111102-beta" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/GroversAlgorithm/GroversAlgorithm.csproj
+++ b/GroversAlgorithm/GroversAlgorithm.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20102604">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20111102-beta">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Katas" Version="0.13.20102604" />
-    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.13.20102604" />
+    <PackageReference Include="Microsoft.Quantum.Katas" Version="0.13.20111102-beta" />
+    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.13.20111102-beta" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/JointMeasurements/JointMeasurements.csproj
+++ b/JointMeasurements/JointMeasurements.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20102604">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20111102-beta">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Katas" Version="0.13.20102604" />
-    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.13.20102604" />
+    <PackageReference Include="Microsoft.Quantum.Katas" Version="0.13.20111102-beta" />
+    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.13.20111102-beta" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/KeyDistribution_BB84/KeyDistribution_BB84.csproj
+++ b/KeyDistribution_BB84/KeyDistribution_BB84.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20102604">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20111102-beta">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Katas" Version="0.13.20102604" />
-    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.13.20102604" />
+    <PackageReference Include="Microsoft.Quantum.Katas" Version="0.13.20111102-beta" />
+    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.13.20111102-beta" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/MagicSquareGame/MagicSquareGame.csproj
+++ b/MagicSquareGame/MagicSquareGame.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20102604">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20111102-beta">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Katas" Version="0.13.20102604" />
-    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.13.20102604" />
+    <PackageReference Include="Microsoft.Quantum.Katas" Version="0.13.20111102-beta" />
+    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.13.20111102-beta" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/Measurements/Measurements.csproj
+++ b/Measurements/Measurements.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20102604">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20111102-beta">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Katas" Version="0.13.20102604" />
-    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.13.20102604" />
+    <PackageReference Include="Microsoft.Quantum.Katas" Version="0.13.20111102-beta" />
+    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.13.20111102-beta" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/PhaseEstimation/PhaseEstimation.csproj
+++ b/PhaseEstimation/PhaseEstimation.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20102604">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20111102-beta">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Katas" Version="0.13.20102604" />
-    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.13.20102604" />
+    <PackageReference Include="Microsoft.Quantum.Katas" Version="0.13.20111102-beta" />
+    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.13.20111102-beta" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/QEC_BitFlipCode/QEC_BitFlipCode.csproj
+++ b/QEC_BitFlipCode/QEC_BitFlipCode.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20102604">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20111102-beta">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
@@ -11,8 +11,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Katas" Version="0.13.20102604" />
-    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.13.20102604" />
+    <PackageReference Include="Microsoft.Quantum.Katas" Version="0.13.20111102-beta" />
+    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.13.20111102-beta" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/QFT/QFT.csproj
+++ b/QFT/QFT.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20102604">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20111102-beta">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Katas" Version="0.13.20102604" />
-    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.13.20102604" />
+    <PackageReference Include="Microsoft.Quantum.Katas" Version="0.13.20111102-beta" />
+    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.13.20111102-beta" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/RippleCarryAdder/RippleCarryAdder.csproj
+++ b/RippleCarryAdder/RippleCarryAdder.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20102604">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20111102-beta">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Katas" Version="0.13.20102604" />
-    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.13.20102604" />
+    <PackageReference Include="Microsoft.Quantum.Katas" Version="0.13.20111102-beta" />
+    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.13.20111102-beta" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/SimonsAlgorithm/SimonsAlgorithm.csproj
+++ b/SimonsAlgorithm/SimonsAlgorithm.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20102604">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20111102-beta">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Katas" Version="0.13.20102604" />
-    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.13.20102604" />
+    <PackageReference Include="Microsoft.Quantum.Katas" Version="0.13.20111102-beta" />
+    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.13.20111102-beta" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/SolveSATWithGrover/SolveSATWithGrover.csproj
+++ b/SolveSATWithGrover/SolveSATWithGrover.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20102604">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20111102-beta">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Katas" Version="0.13.20102604" />
-    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.13.20102604" />
+    <PackageReference Include="Microsoft.Quantum.Katas" Version="0.13.20111102-beta" />
+    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.13.20111102-beta" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/SuperdenseCoding/SuperdenseCoding.csproj
+++ b/SuperdenseCoding/SuperdenseCoding.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20102604">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20111102-beta">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Katas" Version="0.13.20102604" />
-    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.13.20102604" />
+    <PackageReference Include="Microsoft.Quantum.Katas" Version="0.13.20111102-beta" />
+    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.13.20111102-beta" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/Superposition/Superposition.csproj
+++ b/Superposition/Superposition.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20102604">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20111102-beta">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Katas" Version="0.13.20102604" />
-    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.13.20102604" />
+    <PackageReference Include="Microsoft.Quantum.Katas" Version="0.13.20111102-beta" />
+    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.13.20111102-beta" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/Teleportation/Teleportation.csproj
+++ b/Teleportation/Teleportation.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20102604">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20111102-beta">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Katas" Version="0.13.20102604" />
-    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.13.20102604" />
+    <PackageReference Include="Microsoft.Quantum.Katas" Version="0.13.20111102-beta" />
+    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.13.20111102-beta" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/TruthTables/TruthTables.csproj
+++ b/TruthTables/TruthTables.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20102604">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20111102-beta">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Katas" Version="0.13.20102604" />
-    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.13.20102604" />
+    <PackageReference Include="Microsoft.Quantum.Katas" Version="0.13.20111102-beta" />
+    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.13.20111102-beta" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/UnitaryPatterns/UnitaryPatterns.csproj
+++ b/UnitaryPatterns/UnitaryPatterns.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20102604">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20111102-beta">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Katas" Version="0.13.20102604" />
-    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.13.20102604" />
+    <PackageReference Include="Microsoft.Quantum.Katas" Version="0.13.20111102-beta" />
+    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.13.20111102-beta" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/scripts/Update-QDKVersion.ps1
+++ b/scripts/Update-QDKVersion.ps1
@@ -69,7 +69,7 @@ $dockerPath = Join-Path $katasRoot "Dockerfile"
     } | Set-Content -Path $dockerPath
 
 
-$ps1String = "Microsoft.Quantum.IQSharp --version $versionRegex"
+$ps1String = "Microsoft.Quantum.IQSharp --version 0.13.20111102-beta
 $ps1Path = Join-Path $katasRoot "scripts\install-iqsharp.ps1"
 (Get-Content -Path $ps1Path) | ForEach-Object {
          $isQuantumPackage = $_ -match $ps1String

--- a/scripts/install-iqsharp.ps1
+++ b/scripts/install-iqsharp.ps1
@@ -19,7 +19,7 @@ try {
 if ($install) {
     try {
         Write-Host ("Installing Microsoft.Quantum.IQSharp at $Env:TOOLS_DIR")
-        dotnet tool install Microsoft.Quantum.IQSharp --version 0.13.20102604 --tool-path $Env:TOOLS_DIR
+        dotnet tool install Microsoft.Quantum.IQSharp --version 0.13.20111102-beta --tool-path $Env:TOOLS_DIR
 
         # dotnet-iqsharp writes some output to stderr, which causes Powershell to throw
         # unless $ErrorActionPreference is set to 'Continue'.

--- a/tutorials/ExploringDeutschJozsaAlgorithm/DeutschJozsaAlgorithmTutorial.csproj
+++ b/tutorials/ExploringDeutschJozsaAlgorithm/DeutschJozsaAlgorithmTutorial.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20102604">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20111102-beta">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
@@ -7,8 +7,8 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Katas" Version="0.13.20102604" />
-    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.13.20102604" />
+    <PackageReference Include="Microsoft.Quantum.Katas" Version="0.13.20111102-beta" />
+    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.13.20111102-beta" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/tutorials/ExploringGroversAlgorithm/ExploringGroversAlgorithmTutorial.csproj
+++ b/tutorials/ExploringGroversAlgorithm/ExploringGroversAlgorithmTutorial.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20102604">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20111102-beta">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
@@ -7,7 +7,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.13.20102604" />
+    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.13.20111102-beta" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/tutorials/MultiQubitGates/MultiQubitGates.csproj
+++ b/tutorials/MultiQubitGates/MultiQubitGates.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20102604">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20111102-beta">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Katas" Version="0.13.20102604" />
-    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.13.20102604" />
+    <PackageReference Include="Microsoft.Quantum.Katas" Version="0.13.20111102-beta" />
+    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.13.20111102-beta" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/tutorials/MultiQubitSystems/MultiQubitSystems.csproj
+++ b/tutorials/MultiQubitSystems/MultiQubitSystems.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20102604">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20111102-beta">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Katas" Version="0.13.20102604" />
-    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.13.20102604" />
+    <PackageReference Include="Microsoft.Quantum.Katas" Version="0.13.20111102-beta" />
+    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.13.20111102-beta" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/tutorials/QuantumClassification/QuantumClassification.csproj
+++ b/tutorials/QuantumClassification/QuantumClassification.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20102604">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20111102-beta">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.MachineLearning" Version="0.13.20102604" />
+    <PackageReference Include="Microsoft.Quantum.MachineLearning" Version="0.13.20111102-beta" />
     <PackageReference Include="System.Text.Json" Version="4.6.0" />
   </ItemGroup>
 </Project>

--- a/tutorials/RandomNumberGeneration/RandomNumberGenerationTutorial.csproj
+++ b/tutorials/RandomNumberGeneration/RandomNumberGenerationTutorial.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20102604">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20111102-beta">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
@@ -7,8 +7,8 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Katas" Version="0.13.20102604" />
-    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.13.20102604" />
+    <PackageReference Include="Microsoft.Quantum.Katas" Version="0.13.20111102-beta" />
+    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.13.20111102-beta" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/tutorials/SingleQubitGates/SingleQubitGates.csproj
+++ b/tutorials/SingleQubitGates/SingleQubitGates.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20102604">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20111102-beta">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Katas" Version="0.13.20102604" />
-    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.13.20102604" />
+    <PackageReference Include="Microsoft.Quantum.Katas" Version="0.13.20111102-beta" />
+    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.13.20111102-beta" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/utilities/Common/Common.csproj
+++ b/utilities/Common/Common.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20102604">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20111102-beta">
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>

--- a/utilities/DumpUnitary/DumpUnitary.csproj
+++ b/utilities/DumpUnitary/DumpUnitary.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20102604">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20111102-beta">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>

--- a/utilities/Microsoft.Quantum.Katas/Microsoft.Quantum.Katas.csproj
+++ b/utilities/Microsoft.Quantum.Katas/Microsoft.Quantum.Katas.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.IQSharp.Jupyter" Version="0.13.20102604" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.Quantum.IQSharp.Jupyter" Version="0.13.20111102-beta" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This change updates references to the Quantum SDK such to make them compatible with the latest version of the compiler and enable local e2e builds.