### PR TITLE
Avoid pyzmq incompatibility in CI build

### DIFF
--- a/scripts/steps-init.yml
+++ b/scripts/steps-init.yml
@@ -15,7 +15,7 @@ steps:
     architecture: 'x64'
   displayName: 'Use Python 3.6'
 
-- script: pip install setuptools wheel pytest jupyter numpy matplotlib qsharp
+- script: pip install setuptools wheel pytest jupyter numpy matplotlib qsharp pyzmq==19.0.2
   displayName: 'Install Python tools'
 
 - powershell: ./install-iqsharp.ps1


### PR DESCRIPTION
A recent release of the `pyzmq` package (20.0.0) has resulted in some type of intermittent deadlock issues when running Jupyter with IQ#. We can see this clearly in this repo, because many of the recent Katas CI builds are failing.

We haven't yet identified the root cause of this incompatibility, but we want to avoid getting that behavior in our CI builds, so this change pins the `pyzmq` version to the previous release (19.0.2).