### PR TITLE
Update build trigger

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,12 +1,19 @@
 name: $(Build.Major).$(Build.Minor).$(BuildId)
 
-trigger:
-- main
+trigger: none
 
 pr:
 - main
 - feature/*
 - release/*
+
+schedules:
+- cron: "0 9 * * Sat"
+  displayName: 'Build for Component Governance'
+  branches:
+    include:
+    - main
+  always: true
 
 variables:
   Build.Major: 1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,6 +1,7 @@
 name: $(Build.Major).$(Build.Minor).$(BuildId)
 
-trigger: none
+trigger:
+- main
 
 pr:
 - main


### PR DESCRIPTION
Add a trigger to build on `main` to keep component governance up to date.