### PR TITLE
Rename "borrow" variables to avoid breaking keyword change

### DIFF
--- a/RippleCarryAdder/ReferenceImplementation.qs
+++ b/RippleCarryAdder/ReferenceImplementation.qs
@@ -276,15 +276,15 @@ namespace Quantum.Kata.RippleCarryAdder {
     //////////////////////////////////////////////////////////////////
 
     // Task 4.1. N-bit subtractor
-    operation Subtractor_Reference (a : Qubit[], b : Qubit[], borrow : Qubit) : Unit is Adj {
+    operation Subtractor_Reference (a : Qubit[], b : Qubit[], borrowed : Qubit) : Unit is Adj {
         // transform b into 2ᴺ - 1 - b
         ApplyToEachA(X, b);
 
         // compute (2ᴺ - 1 - b) + a = 2ᴺ - 1 - (b - a) using existing adder
         // if this produced a carry, then (2ᴺ - 1 - (b - a)) > 2ᴺ - 1, so (b - a) < 0, and we need a borrow
         // this means we can use the carry qubit from the addition as the borrow qubit
-        ArbitraryMajUmaAdder_Reference(a, b, borrow);
-        
+        ArbitraryMajUmaAdder_Reference(a, b, borrowed);
+
         // transform 2ᴺ - 1 - (b - a) into b - a
         ApplyToEachA(X, b);
     }

--- a/RippleCarryAdder/ReferenceImplementation.qs
+++ b/RippleCarryAdder/ReferenceImplementation.qs
@@ -276,14 +276,14 @@ namespace Quantum.Kata.RippleCarryAdder {
     //////////////////////////////////////////////////////////////////
 
     // Task 4.1. N-bit subtractor
-    operation Subtractor_Reference (a : Qubit[], b : Qubit[], borrowed : Qubit) : Unit is Adj {
+    operation Subtractor_Reference (a : Qubit[], b : Qubit[], borrowBit : Qubit) : Unit is Adj {
         // transform b into 2ᴺ - 1 - b
         ApplyToEachA(X, b);
 
         // compute (2ᴺ - 1 - b) + a = 2ᴺ - 1 - (b - a) using existing adder
         // if this produced a carry, then (2ᴺ - 1 - (b - a)) > 2ᴺ - 1, so (b - a) < 0, and we need a borrow
         // this means we can use the carry qubit from the addition as the borrow qubit
-        ArbitraryMajUmaAdder_Reference(a, b, borrowed);
+        ArbitraryMajUmaAdder_Reference(a, b, borrowBit);
 
         // transform 2ᴺ - 1 - (b - a) into b - a
         ApplyToEachA(X, b);

--- a/RippleCarryAdder/RippleCarryAdder.ipynb
+++ b/RippleCarryAdder/RippleCarryAdder.ipynb
@@ -663,12 +663,12 @@
     "\n",
     "  1. $N$-qubit register `a` in an arbitrary state $|\\phi\\rangle$,\n",
     "  2. $N$-qubit register `b` in an arbitrary state $|\\psi\\rangle$,\n",
-    "  3. qubit `borrowed` in state $|0\\rangle$.\n",
+    "  3. qubit `borrowBit` in state $|0\\rangle$.\n",
     "\n",
     "**Goal:** Construct an N-bit binary subtractor.\n",
     "\n",
     "* Transform register `b` into the state $|\\psi - \\phi\\rangle$.\n",
-    "* Set qubit `borrowed` to $|1\\rangle$ if that subtraction requires a borrow.\n",
+    "* Set qubit `borrowBit` to $|1\\rangle$ if that subtraction requires a borrow.\n",
     "* Leave register `a` unchanged.\n",
     "\n",
     "<br/>\n",
@@ -686,7 +686,7 @@
    "source": [
     "%kata T41_Subtractor\n",
     "\n",
-    "operation Subtractor (a : Qubit[], b : Qubit[], borrowed : Qubit) : Unit is Adj {\n",
+    "operation Subtractor (a : Qubit[], b : Qubit[], borrowBit : Qubit) : Unit is Adj {\n",
     "    // ...\n",
     "}"
    ]

--- a/RippleCarryAdder/RippleCarryAdder.ipynb
+++ b/RippleCarryAdder/RippleCarryAdder.ipynb
@@ -663,12 +663,12 @@
     "\n",
     "  1. $N$-qubit register `a` in an arbitrary state $|\\phi\\rangle$,\n",
     "  2. $N$-qubit register `b` in an arbitrary state $|\\psi\\rangle$,\n",
-    "  3. qubit `borrow` in state $|0\\rangle$.\n",
+    "  3. qubit `borrowed` in state $|0\\rangle$.\n",
     "\n",
     "**Goal:** Construct an N-bit binary subtractor.\n",
     "\n",
     "* Transform register `b` into the state $|\\psi - \\phi\\rangle$.\n",
-    "* Set qubit `borrow` to $|1\\rangle$ if that subtraction requires a borrow.\n",
+    "* Set qubit `borrowed` to $|1\\rangle$ if that subtraction requires a borrow.\n",
     "* Leave register `a` unchanged.\n",
     "\n",
     "<br/>\n",
@@ -686,7 +686,7 @@
    "source": [
     "%kata T41_Subtractor\n",
     "\n",
-    "operation Subtractor (a : Qubit[], b : Qubit[], borrow : Qubit) : Unit is Adj {\n",
+    "operation Subtractor (a : Qubit[], b : Qubit[], borrowed : Qubit) : Unit is Adj {\n",
     "    // ...\n",
     "}"
    ]

--- a/RippleCarryAdder/Tasks.qs
+++ b/RippleCarryAdder/Tasks.qs
@@ -331,12 +331,12 @@ namespace Quantum.Kata.RippleCarryAdder {
     // Inputs:
     //      1) N-qubit register "a" in an arbitrary state |φ⟩,
     //      2) N-qubit register "b" in an arbitrary state |ψ⟩,
-    //      3) qubit "borrowed" in state |0⟩.
+    //      3) qubit "borrowBit" in state |0⟩.
     // Goal: construct a binary subtractor:
     //      1) transform register "b" into the state |ψ - φ⟩ ,
-    //      2) set the "borrowed" qubit to |1⟩ if that subtraction required a borrow.
+    //      2) set the "borrowBit" qubit to |1⟩ if that subtraction required a borrow.
     //         Leave register "a" unchanged.
-    operation Subtractor (a : Qubit[], b : Qubit[], borrowed : Qubit) : Unit is Adj {
+    operation Subtractor (a : Qubit[], b : Qubit[], borrowBit : Qubit) : Unit is Adj {
         // Hint: use the adder you already built, 
         // and experiment with inverting the registers before and after the addition.
 

--- a/RippleCarryAdder/Tasks.qs
+++ b/RippleCarryAdder/Tasks.qs
@@ -331,19 +331,19 @@ namespace Quantum.Kata.RippleCarryAdder {
     // Inputs:
     //      1) N-qubit register "a" in an arbitrary state |φ⟩,
     //      2) N-qubit register "b" in an arbitrary state |ψ⟩,
-    //      3) qubit "borrow" in state |0⟩.
+    //      3) qubit "borrowed" in state |0⟩.
     // Goal: construct a binary subtractor:
     //      1) transform register "b" into the state |ψ - φ⟩ ,
-    //      2) set the "borrow" qubit to |1⟩ if that subtraction required a borrow.
+    //      2) set the "borrowed" qubit to |1⟩ if that subtraction required a borrow.
     //         Leave register "a" unchanged.
-    operation Subtractor (a : Qubit[], b : Qubit[], borrow : Qubit) : Unit is Adj {
+    operation Subtractor (a : Qubit[], b : Qubit[], borrowed : Qubit) : Unit is Adj {
         // Hint: use the adder you already built, 
         // and experiment with inverting the registers before and after the addition.
 
         // ...
 
     }
-    
+
 
     //////////////////////////////////////////////////////////////////
     // Part V. Addition and subtraction modulo 2ᴺ

--- a/RippleCarryAdder/Tests.qs
+++ b/RippleCarryAdder/Tests.qs
@@ -48,10 +48,10 @@ namespace Quantum.Kata.RippleCarryAdder {
         let bitsb = input[N ...];
         let a = BoolArrayAsInt(bitsa);
         let b = BoolArrayAsInt(bitsb);
-        let (diff, borrow) = Subtractor_F(max, a, b);
-        return IntAsBoolArray(diff, N) + [borrow];
+        let (diff, borrowed) = Subtractor_F(max, a, b);
+        return IntAsBoolArray(diff, N) + [borrowed];
     }
-    
+
     function BinaryXor (bits : Bool[]) : Bool {
         mutable ans = false;
         for (bit in bits) {

--- a/RippleCarryAdder/Tests.qs
+++ b/RippleCarryAdder/Tests.qs
@@ -48,8 +48,8 @@ namespace Quantum.Kata.RippleCarryAdder {
         let bitsb = input[N ...];
         let a = BoolArrayAsInt(bitsa);
         let b = BoolArrayAsInt(bitsb);
-        let (diff, borrowed) = Subtractor_F(max, a, b);
-        return IntAsBoolArray(diff, N) + [borrowed];
+        let (diff, borrowBit) = Subtractor_F(max, a, b);
+        return IntAsBoolArray(diff, N) + [borrowBit];
     }
 
     function BinaryXor (bits : Bool[]) : Bool {


### PR DESCRIPTION
[QEP 1: Implicitly-Scoped Qubit Allocation](https://github.com/microsoft/qsharp-language/blob/main/Approved/1-implicitly-scoped-qubit-allocation.md) added two new keywords, `use` and `borrow`. This is a breaking change, unfortunately, and the RippleCarryAdder kata is using `borrow` as a variable name. This PR renames it to `borrowed` to avoid the breakage.

Cc: @bettinaheim