### PR TITLE
Update Measurement counting logic

### DIFF
--- a/Measurements/Tests.qs
+++ b/Measurements/Tests.qs
@@ -185,7 +185,7 @@ namespace Quantum.Kata.Measurements {
             }
             // if we have a max number of measurements per solution run specified, check that it is not exceeded
             if (measurementsPerRun > 0) {
-                let nm = GetOracleCallsCount(M) + GetOracleCallsCount(Measure);
+                let nm = GetOracleCallsCount(Measure);
                 EqualityFactB(nm <= 1, true, $"You are allowed to do at most one measurement, and you did {nm}");
             }
 

--- a/QEC_BitFlipCode/Tests.qs
+++ b/QEC_BitFlipCode/Tests.qs
@@ -103,7 +103,7 @@ namespace Quantum.Kata.QEC_BitFlipCode {
             Adjoint statePrep(register);
             AssertAllZero(register);
 
-            let nm = GetOracleCallsCount(M) + GetOracleCallsCount(Measure);
+            let nm = GetOracleCallsCount(Measure);
             Fact(nm <= 1, $"You are allowed to do at most one measurement, and you did {nm}");
         }
     }

--- a/UnitaryPatterns/Tests.qs
+++ b/UnitaryPatterns/Tests.qs
@@ -45,7 +45,6 @@ namespace Quantum.Kata.UnitaryPatterns {
                 op(qs);
                 
                 // Make sure the solution didn't use any measurements
-                Fact(GetOracleCallsCount(M) == 0, "You are not allowed to use measurements in this task");
                 Fact(GetOracleCallsCount(Measure) == 0, "You are not allowed to use measurements in this task");
 
                 // Test that the result matches the k-th column


### PR DESCRIPTION
With the feature work from https://github.com/microsoft/qsharp-runtime/issues/249 merged, the beta packages will now report oracle counts differently. This is expected, as `M` calls into `Measure`, so counting both operations will double count measurements and fail validation of solutions. This adjusts to only count `Measure` in order to ensure the right behavior in the pipeline and when the feature makes it into a public release.

This fixes Measurement counting mechanism should be updated for target package feature. #552