### PR TITLE
Added ability to disable exception printing in CounterSimulator

### DIFF
--- a/DistinguishUnitaries/Tests.qs
+++ b/DistinguishUnitaries/Tests.qs
@@ -79,6 +79,14 @@ namespace Quantum.Kata.DistinguishUnitaries {
         }
         // This check will tell the total number of failed classifications
         Fact(totalMisclassifications == 0, $"{totalMisclassifications} test runs out of {nTotal} returned incorrect state.");
+
+        // Use the following within-apply pattern to display clean message without
+        // additional information from exception (such as stack trace).
+        //
+        // within { DisableExceptionPrinting(); } apply {
+        //    Message($"{totalMisclassifications} test runs out of {nTotal} returned incorrect state.");
+        //    Fact(totalMisclassifications == 0, $"Failure.");
+        // }
     }
     
     

--- a/utilities/Common/CounterSimulator.cs
+++ b/utilities/Common/CounterSimulator.cs
@@ -141,6 +141,30 @@ namespace Microsoft.Quantum.Katas
                 return _sim._multiQubitOperations;
             };
         }
+
+        /// <summary>
+        /// Custom operation to disable exception diagnostics printout.
+        /// Adjoint operation enables printout. WILL NOT WORK IF NESTED!
+        /// </summary>
+        public class DisableExceptionPrintingImpl : DisableExceptionPrinting
+        {
+            CounterSimulator _sim;
+
+            public DisableExceptionPrintingImpl(CounterSimulator m) : base(m) {
+                _sim = m;
+            }
+
+            public override Func<QVoid, QVoid> __Body__ => (__in) => {
+                _sim.DisableExceptionPrinting();
+                return QVoid.Instance;
+            };
+
+            public override Func<QVoid, QVoid> __AdjointBody__ => (__in) => {
+                _sim.EnableExceptionPrinting();
+                return QVoid.Instance;
+            };
+        }
+
         #endregion
 
         #region Counting allocated qubits

--- a/utilities/Common/Utils.qs
+++ b/utilities/Common/Utils.qs
@@ -34,4 +34,8 @@ namespace Quantum.Kata.Utils {
     /// # Summary
     /// Returns the number of multi-qubit operations used by the simulator.
     operation GetMultiQubitOpCount () : Int { body intrinsic; }
+
+    /// # Summary
+    /// Disables printout on exception. Adjoint operation enabled printout. Do not nest!
+    operation DisableExceptionPrinting () : Unit { body intrinsic; adjoint intrinsic; }
 }


### PR DESCRIPTION
Do not merge! Example only.
This is an example of how to make error messages in Test Explorer UI cleaner.
CounterSimulator exposes ability to disable exception printing to Q#.
Example of how to use this ability via apply-within block to print clean message in DistinguishUnitaries.
The example is commented out because Katas package needs to be updated first.