### PR TITLE
Clean up built projects to save space in pipeline

### DIFF
--- a/scripts/validate-projects.ps1
+++ b/scripts/validate-projects.ps1
@@ -24,7 +24,9 @@ function Build-One {
     if ($env:FORCE_CLEANUP -eq "true") {
         # Force cleanup of generated bin and obj folders for this project.
         Write-Host "##[info]Cleaning up bin/obj from $(Split-Path $project -Parent)..."
-        Get-ChildItem -Path (Split-Path $project -Parent) -Recurse | Where-Object { ($_.name -eq "bin" -or $_.name -eq "obj") -and $_.attributes -eq "Directory" } | Remove-Item -recurse -force
+        Get-ChildItem -Path (Split-Path $project -Parent) -Recurse `
+        | Where-Object { ($_.name -eq "bin" -or $_.name -eq "obj") -and $_.attributes -eq "Directory" } `
+        | Remove-Item -recurse -force
     }
 }
 

--- a/scripts/validate-projects.ps1
+++ b/scripts/validate-projects.ps1
@@ -20,6 +20,12 @@ function Build-One {
       /property:QsharpDocsOutDir=$Env:DOCS_OUTDIR
 
   $script:all_ok = ($LastExitCode -eq 0) -and $script:all_ok
+
+    if ($env:FORCE_CLEANUP -eq "true") {
+        # Force cleanup of generated bin and obj folders for this project.
+        Write-Host "##[info]Cleaning up bin/obj from $(Split-Path $project -Parent)..."
+        Get-ChildItem -Path (Split-Path $project -Parent) -Recurse | Where-Object { ($_.name -eq "bin" -or $_.name -eq "obj") -and $_.attributes -eq "Directory" } | Remove-Item -recurse -force
+    }
 }
 
 # Build all Katas solutions


### PR DESCRIPTION
This matches the change in https://github.com/microsoft/Quantum/pull/464 and will help avoid failures where the build pipeline fails because it runs out of space.