### PR TITLE
Fix link to "Q# documentation on quantum states"

### DIFF
--- a/tutorials/Qubit/Qubit.ipynb
+++ b/tutorials/Qubit/Qubit.ipynb
@@ -196,7 +196,7 @@
     "![-i state](./img/Dumpmachine-visualization-state--i.png)\n",
     "\n",
     "\n",
-    "> It is important to note that although we reason about quantum systems in terms of their state, Q# does not have any representation of the quantum state in the language. Instead, state is an internal property of the quantum system, modified using gates. For more information, see [Q# documentation on quantum states](https://docs.microsoft.com/azure/quantum/concepts/dirac-notation#q-gate-sequences-equivalent-to-quantum-states).\n",
+    "> It is important to note that although we reason about quantum systems in terms of their state, Q# does not have any representation of the quantum state in the language. Instead, state is an internal property of the quantum system, modified using gates. For more information, see [Q# documentation on quantum states](https://docs.microsoft.com/azure/quantum/concepts-dirac-notation#q-gate-sequences-equivalent-to-quantum-states).\n",
     "\n",
     "This demo shows how to allocate a qubit and examine its state in Q#. This demo uses quantum gates to manipulate the state of the qubit - we will explain how they work in the next tutorial, so do not worry about them for now. Run the next cell using `Ctrl+Enter` (`⌘+Enter` on Mac), then run the cell after it to see the output."
    ]


### PR DESCRIPTION
The link to "Q# documentation on quantum states" in the Qubit tutorial is incorrect. It has a slash where a dash should be.