### PR TITLE
Refractor tests in QRNG using Delay operation

### DIFF
--- a/tutorials/RandomNumberGeneration/RandomNumberGenerationTutorial.ipynb
+++ b/tutorials/RandomNumberGeneration/RandomNumberGenerationTutorial.ipynb
@@ -191,12 +191,11 @@
     "In exercise 3, we generated numbers in the range $[0, 2^N-1]$ $(1 \\leq N \\leq 10)$. Now let's create an operation that will return a random number in the range $[min, max]$. \n",
     "\n",
     "**Input:** \n",
-    "A $range$ tuple of the form ($min$, $max$) such that ($0 \\leq min \\leq max \\leq 2^{10}-1$).\n",
+    "Two integers $min$ and $max$ ($0 \\leq min \\leq max \\leq 2^{10}-1$).\n",
     "\n",
     "**Goal:** Generate a random number in the range $[min, max]$ with an equal probability of getting each of the numbers in this range.\n",
     "\n",
     "> Useful Q# documentation: \n",
-    "> * [`Math` namespace](https://docs.microsoft.com/qsharp/api/qsharp/microsoft.quantum.math)\n",
     "> * [`BitSizeI` function](https://docs.microsoft.com/en-us/qsharp/api/qsharp/microsoft.quantum.math.bitsizei)"
    ]
   },
@@ -208,8 +207,7 @@
    "source": [
     "%kata T5_RandomNumberInRange\n",
     "\n",
-    "open Microsoft.Quantum.Math;\n",
-    "operation RandomNumberInRange (range : (Int,Int)) : Int {\n",
+    "operation RandomNumberInRange (min : Int, max : Int) : Int {\n",
     "    // ...\n",
     "    return -1;\n",
     "}"

--- a/tutorials/RandomNumberGeneration/RandomNumberGenerationTutorial.ipynb
+++ b/tutorials/RandomNumberGeneration/RandomNumberGenerationTutorial.ipynb
@@ -191,9 +191,13 @@
     "In exercise 3, we generated numbers in the range $[0, 2^N-1]$ $(1 \\leq N \\leq 10)$. Now let's create an operation that will return a random number in the range $[min, max]$. \n",
     "\n",
     "**Input:** \n",
-    "Two integers $min$ and $max$ ($1 \\leq min \\leq max \\leq 2^{10}-1$).\n",
+    "A $range$ tuple of the form ($min$, $max$) such that ($0 \\leq min \\leq max \\leq 2^{10}-1$).\n",
     "\n",
-    "**Goal:** Generate a random number in the range $[min, max]$ with an equal probability of getting each of the numbers in this range."
+    "**Goal:** Generate a random number in the range $[min, max]$ with an equal probability of getting each of the numbers in this range.\n",
+    "\n",
+    "> Useful Q# documentation: \n",
+    "> * [`Math` namespace](https://docs.microsoft.com/qsharp/api/qsharp/microsoft.quantum.math)\n",
+    "> * [`BitSizeI` function](https://docs.microsoft.com/en-us/qsharp/api/qsharp/microsoft.quantum.math.bitsizei)"
    ]
   },
   {
@@ -204,7 +208,8 @@
    "source": [
     "%kata T5_RandomNumberInRange\n",
     "\n",
-    "operation RandomNumberInRange (min : Int, max : Int) : Int {\n",
+    "open Microsoft.Quantum.Math;\n",
+    "operation RandomNumberInRange (range : (Int,Int)) : Int {\n",
     "    // ...\n",
     "    return -1;\n",
     "}"
@@ -231,7 +236,7 @@
    "file_extension": ".qs",
    "mimetype": "text/x-qsharp",
    "name": "qsharp",
-   "version": "0.12"
+   "version": "0.14"
   }
  },
  "nbformat": 4,

--- a/tutorials/RandomNumberGeneration/ReferenceImplementation.qs
+++ b/tutorials/RandomNumberGeneration/ReferenceImplementation.qs
@@ -48,7 +48,8 @@ namespace Quantum.Kata.RandomNumberGeneration {
     }
 
     // Exercise 5.
-    operation RandomNumberInRange_Reference (min : Int, max : Int) : Int {
+    operation RandomNumberInRange_Reference (range : (Int,Int)) : Int {
+        let (min,max) = range;
         let nBits = BitSizeI(max);
         mutable output = 0; 
         repeat {

--- a/tutorials/RandomNumberGeneration/ReferenceImplementation.qs
+++ b/tutorials/RandomNumberGeneration/ReferenceImplementation.qs
@@ -44,8 +44,7 @@ namespace Quantum.Kata.RandomNumberGeneration {
     }
 
     // Exercise 5.
-    operation RandomNumberInRange_Reference (range : (Int,Int)) : Int {
-        let (min,max) = range;
+    operation RandomNumberInRange_Reference (min : Int, max : Int) : Int {
         let nBits = BitSizeI(max);
         mutable output = 0; 
         repeat {

--- a/tutorials/RandomNumberGeneration/ReferenceImplementation.qs
+++ b/tutorials/RandomNumberGeneration/ReferenceImplementation.qs
@@ -10,11 +10,7 @@
 
 namespace Quantum.Kata.RandomNumberGeneration {
     
-    open Microsoft.Quantum.Arrays;
-    open Microsoft.Quantum.Diagnostics;
     open Microsoft.Quantum.Intrinsic;
-    open Microsoft.Quantum.Canon;
-    open Microsoft.Quantum.Measurement;
     open Microsoft.Quantum.Math;
     
 

--- a/tutorials/RandomNumberGeneration/Tests.qs
+++ b/tutorials/RandomNumberGeneration/Tests.qs
@@ -23,7 +23,7 @@ namespace Quantum.Kata.RandomNumberGeneration {
     /// (a single run can fail with non-negligible probability even for a correct solution).
     /// # Input
     /// ## testingHarness
-    /// Helper test operation which verifies the user answer and reference implementation
+    /// Test operation which verifies the user's solution.
     operation RetryTestOperation (testingHarness : (Unit => Bool)) : Unit {
         let numRetries = 3;
         mutable sufficientlyRandom = false;

--- a/tutorials/RandomNumberGeneration/Tests.qs
+++ b/tutorials/RandomNumberGeneration/Tests.qs
@@ -44,7 +44,8 @@ namespace Quantum.Kata.RandomNumberGeneration {
     operation T1_RandomBit () : Unit {
         Message("Testing one random bit generation...");
         let solution = RandomBit;
-        let testingHarness = Delay(CheckUniformDistribution,(solution, 0, 1, 1000), _); // // Delay() converts CheckUniformDistribution to parameterless operation
+        // Delay() converts CheckUniformDistribution to a parameterless operation
+        let testingHarness = Delay(CheckUniformDistribution, (solution, 0, 1, 1000), _);
         RetryTestOperation(testingHarness);
         Message("Test passed");
     }
@@ -55,7 +56,8 @@ namespace Quantum.Kata.RandomNumberGeneration {
     operation T2_RandomTwoBits () : Unit {
         Message("Testing two random bits generation...");
         let solution = RandomTwoBits;
-        let testingHarness = Delay(CheckUniformDistribution, (solution, 0, 3, 1000), _); // Delay() converts CheckUniformDistribution to parameterless operation
+        // Delay() converts CheckUniformDistribution to a parameterless operation
+        let testingHarness = Delay(CheckUniformDistribution, (solution, 0, 3, 1000), _);
         RetryTestOperation(testingHarness);
         Message("Test passed");
     }
@@ -68,9 +70,9 @@ namespace Quantum.Kata.RandomNumberGeneration {
         // Test random number generation for 1, 2, 3, 10 bits
         for N in [1, 2, 3, 10] {
             Message($"Testing N = {N}...");
-            let max = (1<<<N) - 1;
-            let solution = Delay(RandomNBits, N, _); // Delay() converts RandomNBits to a parameterless operation
-            let testingHarness = Delay(CheckUniformDistribution, (solution, 0, max, 1000), _); // Delay() converts CheckUniformDistribution to parameterless operation
+            let max = (1 <<< N) - 1;
+            let solution = Delay(RandomNBits, N, _);
+            let testingHarness = Delay(CheckUniformDistribution, (solution, 0, max, 1000), _);
             RetryTestOperation(testingHarness);
             Message($"Test passed for N = {N}");
 	    }
@@ -83,7 +85,8 @@ namespace Quantum.Kata.RandomNumberGeneration {
     /// # Input
     /// ## op
     /// Random number generation operation to be tested.
-    /// ## range
+    /// The parameters to this operation are provided by the caller using Delay().
+    /// ## min, max
     /// Minimal and maximal numbers in the range to be generated, inclusive.
     /// ## nRuns
     /// The number of random numbers to generate for test.
@@ -102,7 +105,7 @@ namespace Quantum.Kata.RandomNumberGeneration {
         let highRange = idealMean + 3.0 * standardDeviation;
 
         let idealCopiesGenerated = IntAsDouble(nRuns) / IntAsDouble(max-min+1);
-        let minimumCopiesGenerated = ( 0.8 * idealCopiesGenerated > 40.0 ) ? 0.8 * idealCopiesGenerated | 0.0;
+        let minimumCopiesGenerated = (0.8 * idealCopiesGenerated > 40.0) ? 0.8 * idealCopiesGenerated | 0.0;
 
         mutable counts = ConstantArray(max + 1, 0);
         mutable average = 0.0;
@@ -157,11 +160,10 @@ namespace Quantum.Kata.RandomNumberGeneration {
     @Test("Microsoft.Quantum.Katas.CounterSimulator")
     operation T4_WeightedRandomBit () : Unit {
         ResetOracleCallsCount();
-        for x in [0.0, 0.25, 0.5, 0.75, 1.0]
-        {
+        for x in [0.0, 0.25, 0.5, 0.75, 1.0] {
             Message($"Testing generating zero with {x*100.0}% probability...");
-            let solution = Delay(WeightedRandomBit, x, _); // Delay() converts WeightedRandomBit to parameterless operation
-            let testingHarness = Delay(CheckXPercentZero, (solution, x), _); // Delay() converts CheckXPercentZero to parameterless operation
+            let solution = Delay(WeightedRandomBit, x, _);
+            let testingHarness = Delay(CheckXPercentZero, (solution, x), _);
             RetryTestOperation(testingHarness);
             Message($"Test passed for generating zero with {x*100.0}% probability");
         }
@@ -214,10 +216,10 @@ namespace Quantum.Kata.RandomNumberGeneration {
     // Exercise 5.
     @Test("Microsoft.Quantum.Katas.CounterSimulator")
     operation T5_RandomNumberInRange () : Unit {
-        for (min,max) in [(1, 3), (27, 312), (0, 3), (0, 1023)] {
+        for (min, max) in [(1, 3), (27, 312), (0, 3), (0, 1023)] {
             Message($"Testing for min = {min} and max = {max}...");
-            let solution = Delay(RandomNumberInRange, (min,max), _); // Delay() converts RandomNumberInRange to parameterless operation
-            let testingHarness = Delay(CheckUniformDistribution, (solution, min, max, 1000), _); // Delay() converts CheckUniformDistribution to parameterless operation
+            let solution = Delay(RandomNumberInRange, (min,max), _);
+            let testingHarness = Delay(CheckUniformDistribution, (solution, min, max, 1000), _);
             RetryTestOperation(testingHarness);
             Message($"Test passed for min = {min} and max = {max}");
 	    }

--- a/tutorials/RandomNumberGeneration/Tests.qs
+++ b/tutorials/RandomNumberGeneration/Tests.qs
@@ -22,14 +22,14 @@ namespace Quantum.Kata.RandomNumberGeneration {
     /// Helper operation to rerun test operation several times
     /// (a single run can fail with non-negligible probability even for a correct solution).
     /// # Input
-    /// ## testOp
+    /// ## testingHarness
     /// Helper test operation which verifies the user answer and reference implementation
-    operation RetryTestOperation (testOp : (Unit => Bool)) : Unit {
+    operation RetryTestOperation (testingHarness : (Unit => Bool)) : Unit {
         let numRetries = 3;
         mutable sufficientlyRandom = false;
         mutable attemptNum = 1;
         repeat {
-            set sufficientlyRandom = testOp();
+            set sufficientlyRandom = testingHarness();
             set attemptNum += 1;
         } until (sufficientlyRandom or attemptNum > numRetries);
 
@@ -43,10 +43,9 @@ namespace Quantum.Kata.RandomNumberGeneration {
     @Test("Microsoft.Quantum.Katas.CounterSimulator")
     operation T1_RandomBit () : Unit {
         Message("Testing one random bit generation...");
-        let userOp = RandomBit;
-        let testUserOp = CheckUniformDistribution(_, (0,1), 1000); // testUserOp takes userOp of the form (Unit=>Int)
-        let testOp = Delay(testUserOp, userOp, _); // // Delay() converts testUserOp to parameterless operation
-        RetryTestOperation(testOp);
+        let solution = RandomBit;
+        let testingHarness = Delay(CheckUniformDistribution,(solution, 0, 1, 1000), _); // // Delay() converts CheckUniformDistribution to parameterless operation
+        RetryTestOperation(testingHarness);
         Message("Test passed");
     }
 
@@ -55,10 +54,9 @@ namespace Quantum.Kata.RandomNumberGeneration {
     @Test("Microsoft.Quantum.Katas.CounterSimulator")
     operation T2_RandomTwoBits () : Unit {
         Message("Testing two random bits generation...");
-        let userOp = RandomTwoBits;
-        let testUserOp = CheckUniformDistribution(_, (0,3), 1000); // testUserOp takes userOp of the form (Unit=>Int)
-        let testOp = Delay(testUserOp, userOp, _); // Delay() converts testUserOp to parameterless operation
-        RetryTestOperation(testOp);
+        let solution = RandomTwoBits;
+        let testingHarness = Delay(CheckUniformDistribution, (solution, 0, 3, 1000), _); // Delay() converts CheckUniformDistribution to parameterless operation
+        RetryTestOperation(testingHarness);
         Message("Test passed");
     }
     
@@ -71,10 +69,9 @@ namespace Quantum.Kata.RandomNumberGeneration {
         for N in [1, 2, 3, 10] {
             Message($"Testing N = {N}...");
             let max = (1<<<N) - 1;
-            let userOp = Delay(RandomNBits, N, _); // Delay() converts RandomNBits to a parameterless operation
-            let testUserOp = CheckUniformDistribution(_, (0,max), 1000); // testUserOp takes userOp of the form (Unit=>Int)
-            let testOp = Delay(testUserOp, userOp, _); // Delay() converts testUserOp to parameterless operation
-            RetryTestOperation(testOp);
+            let solution = Delay(RandomNBits, N, _); // Delay() converts RandomNBits to a parameterless operation
+            let testingHarness = Delay(CheckUniformDistribution, (solution, 0, max, 1000), _); // Delay() converts CheckUniformDistribution to parameterless operation
+            RetryTestOperation(testingHarness);
             Message($"Test passed for N = {N}");
 	    }
     }
@@ -90,8 +87,7 @@ namespace Quantum.Kata.RandomNumberGeneration {
     /// Minimal and maximal numbers in the range to be generated, inclusive.
     /// ## nRuns
     /// The number of random numbers to generate for test.
-    operation CheckUniformDistribution (op : (Unit => Int), range : (Int,Int), nRuns : Int) : Bool {
-        let (min,max) = range;
+    operation CheckUniformDistribution (op : (Unit => Int), min : Int, max : Int, nRuns : Int) : Bool {
         let idealMean = 0.5 * IntAsDouble(max + min) ;
         let rangeDividedByTwo = 0.5 * IntAsDouble(max - min);
         // Variance = a*(a+1)/3, where a = (max-min)/2
@@ -164,10 +160,9 @@ namespace Quantum.Kata.RandomNumberGeneration {
         for x in [0.0, 0.25, 0.5, 0.75, 1.0]
         {
             Message($"Testing generating zero with {x*100.0}% probability...");
-            let userOp = Delay(WeightedRandomBit, x, _); // Delay() converts WeightedRandomBit to parameterless operation
-            let testUserOp = CheckXPercentZero(_, x); // testUserOp takes userOp of the form (Unit=>Int)
-            let testOp = Delay(testUserOp, userOp, _); // Delay() converts testUserOp to parameterless operation
-            RetryTestOperation(testOp);
+            let solution = Delay(WeightedRandomBit, x, _); // Delay() converts WeightedRandomBit to parameterless operation
+            let testingHarness = Delay(CheckXPercentZero, (solution, x), _); // Delay() converts CheckXPercentZero to parameterless operation
+            RetryTestOperation(testingHarness);
             Message($"Test passed for generating zero with {x*100.0}% probability");
         }
         CheckRandomCalls();
@@ -219,13 +214,11 @@ namespace Quantum.Kata.RandomNumberGeneration {
     // Exercise 5.
     @Test("Microsoft.Quantum.Katas.CounterSimulator")
     operation T5_RandomNumberInRange () : Unit {
-        for range in [(1, 3), (27, 312), (0, 3), (0, 1023)] {
-            let (min,max) = range;
+        for (min,max) in [(1, 3), (27, 312), (0, 3), (0, 1023)] {
             Message($"Testing for min = {min} and max = {max}...");
-            let userOp = Delay(RandomNumberInRange, range, _); // Delay() converts RandomNumberInRange to parameterless operation
-            let testUserOp = CheckUniformDistribution(_, range, 1000); // testUserOp takes userOp of the form (Unit=>Int)
-            let testOp = Delay(testUserOp, userOp, _); // Delay() converts testUserOp to parameterless operation
-            RetryTestOperation(testOp);
+            let solution = Delay(RandomNumberInRange, (min,max), _); // Delay() converts RandomNumberInRange to parameterless operation
+            let testingHarness = Delay(CheckUniformDistribution, (solution, min, max, 1000), _); // Delay() converts CheckUniformDistribution to parameterless operation
+            RetryTestOperation(testingHarness);
             Message($"Test passed for min = {min} and max = {max}");
 	    }
     }


### PR DESCRIPTION
Relates to the second point in [Issue #557](https://github.com/microsoft/QuantumKatas/issues/557)

**Changes**
- Converted the user operations to the parameterless operations using `Delay` operation
- Removed wrapper functions
- Unified `RetryCheckUniformDistribution` and `RetryCheckXPercentZero` to `RetryTestOperation`