### PR TITLE
Fix docs for %kata and %check_kata

### DIFF
--- a/utilities/Microsoft.Quantum.Katas/CheckKataMagic.cs
+++ b/utilities/Microsoft.Quantum.Katas/CheckKataMagic.cs
@@ -32,13 +32,13 @@ namespace Microsoft.Quantum.Katas
                 {
                     "To check a test called `Test`:\n" +
                     "```\n" +
-                    "In []: %check_kata T101_StateFlip \n",
-                    "  ...: operation StateFlip (q : Qubit) : Unit is Adj + Ctl {\n",
-                    "           // The Pauli X gate will change the |0⟩ state to the |1⟩ state and vice versa.\n",
-                    "           // Type X(q);\n",
-                    "           // Then run the cell using Ctrl/⌘+Enter.\n",
-                    "\n",
-                    "           // ...\n",
+                    "In []: %check_kata T101_StateFlip \n" +
+                    "     : operation StateFlip (q : Qubit) : Unit is Adj + Ctl {\n" +
+                    "           // The Pauli X gate will change the |0⟩ state to the |1⟩ state and vice versa.\n" +
+                    "           // Type X(q);\n" +
+                    "           // Then run the cell using Ctrl/⌘+Enter.\n" +
+                    "\n" +
+                    "           // ...\n" +
                     "       }\n" +
                     "Out[]: Success!" +
                     "```\n"

--- a/utilities/Microsoft.Quantum.Katas/KataMagic.cs
+++ b/utilities/Microsoft.Quantum.Katas/KataMagic.cs
@@ -31,13 +31,13 @@ namespace Microsoft.Quantum.Katas
                 {
                     "To run a test called `Test`:\n" +
                     "```\n" +
-                    "In []: %kata T101_StateFlip \n",
-                    "  ...: operation StateFlip (q : Qubit) : Unit is Adj + Ctl {\n",
-                    "           // The Pauli X gate will change the |0⟩ state to the |1⟩ state and vice versa.\n",
-                    "           // Type X(q);\n",
-                    "           // Then run the cell using Ctrl/⌘+Enter.\n",
-                    "\n",
-                    "           // ...\n",
+                    "In []: %kata T101_StateFlip \n" +
+                    "     : operation StateFlip (q : Qubit) : Unit is Adj + Ctl {\n" +
+                    "           // The Pauli X gate will change the |0⟩ state to the |1⟩ state and vice versa.\n" +
+                    "           // Type X(q);\n" +
+                    "           // Then run the cell using Ctrl/⌘+Enter.\n" +
+                    "\n" +
+                    "           // ...\n" +
                     "       }\n" +
                     "Out[]: Qubit in invalid state. Expecting: Zero\n" +
 	                "       \tExpected:\t0\n"+


### PR DESCRIPTION
Commas between lines are treated as dividers between examples.