### PR TITLE
Fix docs for %kata and %check_kata, part 2

### DIFF
--- a/utilities/Microsoft.Quantum.Katas/CheckKataMagic.cs
+++ b/utilities/Microsoft.Quantum.Katas/CheckKataMagic.cs
@@ -33,14 +33,14 @@ namespace Microsoft.Quantum.Katas
                     "To check a test called `Test`:\n" +
                     "```\n" +
                     "In []: %check_kata T101_StateFlip \n" +
-                    "     : operation StateFlip (q : Qubit) : Unit is Adj + Ctl {\n" +
+                    "       operation StateFlip (q : Qubit) : Unit is Adj + Ctl {\n" +
                     "           // The Pauli X gate will change the |0⟩ state to the |1⟩ state and vice versa.\n" +
                     "           // Type X(q);\n" +
                     "           // Then run the cell using Ctrl/⌘+Enter.\n" +
                     "\n" +
                     "           // ...\n" +
                     "       }\n" +
-                    "Out[]: Success!" +
+                    "Out[]: Success!\n" +
                     "```\n"
                 }
             };

--- a/utilities/Microsoft.Quantum.Katas/KataMagic.cs
+++ b/utilities/Microsoft.Quantum.Katas/KataMagic.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Quantum.Katas
                     "To run a test called `Test`:\n" +
                     "```\n" +
                     "In []: %kata T101_StateFlip \n" +
-                    "     : operation StateFlip (q : Qubit) : Unit is Adj + Ctl {\n" +
+                    "       operation StateFlip (q : Qubit) : Unit is Adj + Ctl {\n" +
                     "           // The Pauli X gate will change the |0⟩ state to the |1⟩ state and vice versa.\n" +
                     "           // Type X(q);\n" +
                     "           // Then run the cell using Ctrl/⌘+Enter.\n" +
@@ -42,7 +42,7 @@ namespace Microsoft.Quantum.Katas
                     "Out[]: Qubit in invalid state. Expecting: Zero\n" +
 	                "       \tExpected:\t0\n"+
 	                "       \tActual:\t0.5000000000000002\n" +
-                    "       Try again!" +
+                    "       Try again!\n" +
                     "```\n"
                 }
             };


### PR DESCRIPTION
Fixing two more minor formatting issues with the magics docs:
![image](https://user-images.githubusercontent.com/10113024/119871494-577d2f00-bed7-11eb-80ec-e4078b27975e.png)
