### PR TITLE
[VisualizationTools] Fix Binder timeout and broken images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,8 @@ RUN cd ${HOME} && \
     ./scripts/prebuild-kata.sh tutorials/RandomNumberGeneration RandomNumberGenerationTutorial.ipynb && \
     ./scripts/prebuild-kata.sh tutorials/SingleQubitGates SingleQubitGates.ipynb && \
     ./scripts/prebuild-kata.sh tutorials/SingleQubitSystemMeasurements SingleQubitSystemMeasurements.ipynb && \
-    ./scripts/prebuild-kata.sh tutorials/VisualizationTools VisualizationTools.ipynb && \
+    # Exclude VisualizationTools, as %debug cell times out in Binder prebuild
+    #./scripts/prebuild-kata.sh tutorials/VisualizationTools VisualizationTools.ipynb && \
 # To improve performance when loading packages at IQ# kernel initialization time,
 # we remove all online sources for NuGet such that IQ# Package Loading and NuGet dependency
 # resolution won't attempt to resolve package dependencies again (as it was already done

--- a/tutorials/VisualizationTools/VisualizationTools.ipynb
+++ b/tutorials/VisualizationTools/VisualizationTools.ipynb
@@ -237,15 +237,15 @@
     "    </tr>\n",
     "    <tr>\n",
     "        <td style=\"text-align:left; border:1px solid\"><tt>\"LittleEndian\"</tt> (default)</td>\n",
-    "        <td style=\"text-align:center; border:1px solid\"><img src=\"./img/DumpMachine_LittleEndian.png\"/></td>\n",
+    "        <td style=\"text-align:center; border:1px solid\"><img src=\"./img/DumpMachine_LittleEndian.PNG\"/></td>\n",
     "    </tr>\n",
     "    <tr>\n",
     "        <td style=\"text-align:left; border:1px solid\"><tt>\"BigEndian\"</tt></td>\n",
-    "        <td style=\"text-align:center; border:1px solid\"><img src=\"./img/DumpMachine_BigEndian.png\"/></td>\n",
+    "        <td style=\"text-align:center; border:1px solid\"><img src=\"./img/DumpMachine_BigEndian.PNG\"/></td>\n",
     "    </tr>\n",
     "    <tr>\n",
     "        <td style=\"text-align:left; border:1px solid\"><tt>\"Bitstring\"</tt></td>\n",
-    "        <td style=\"text-align:center; border:1px solid\"><img src=\"./img/DumpMachine_Bitstring.png\"/></td>\n",
+    "        <td style=\"text-align:center; border:1px solid\"><img src=\"./img/DumpMachine_Bitstring.PNG\"/></td>\n",
     "    </tr>\n",
     "  </table>\n"
    ]
@@ -487,7 +487,6 @@
   }
  ],
  "metadata": {
-  "celltoolbar": "Tags",
   "kernelspec": {
    "display_name": "Q#",
    "language": "qsharp",


### PR DESCRIPTION
* `%debug` cell times out in Binder prebuild, as it needs to be stepped through manually. We excluded it from the CI build using a different technique, but to enable Binder, the whole notebook has to be excluded from prebuild.
* The images extensions are .PNG, so Linux execution doesn't recognize the lower case paths to them.