### PR TITLE
Reduce the number of katas prebuilt on Binder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,23 +32,23 @@ RUN cd ${HOME} && \
     ./scripts/prebuild-kata.sh BasicGates && \
     ./scripts/prebuild-kata.sh CHSHGame && \
     ./scripts/prebuild-kata.sh DeutschJozsaAlgorithm && \
-    ./scripts/prebuild-kata.sh DistinguishUnitaries && \
+    #./scripts/prebuild-kata.sh DistinguishUnitaries && \
     #./scripts/prebuild-kata.sh GHZGame && \
-    ./scripts/prebuild-kata.sh GraphColoring && \
+    #./scripts/prebuild-kata.sh GraphColoring && \
     ./scripts/prebuild-kata.sh GroversAlgorithm && \
-    ./scripts/prebuild-kata.sh JointMeasurements && \
+    #./scripts/prebuild-kata.sh JointMeasurements && \
     #./scripts/prebuild-kata.sh KeyDistribution_BB84 && \
     #./scripts/prebuild-kata.sh MagicSquareGame && \
     ./scripts/prebuild-kata.sh Measurements && \
-    ./scripts/prebuild-kata.sh PhaseEstimation && \
+    #./scripts/prebuild-kata.sh PhaseEstimation && \
     #./scripts/prebuild-kata.sh QEC_BitFlipCode && \
     ./scripts/prebuild-kata.sh QFT && \
     #./scripts/prebuild-kata.sh RippleCarryAdder && \
-    ./scripts/prebuild-kata.sh SolveSATWithGrover && \
-    ./scripts/prebuild-kata.sh SuperdenseCoding && \
+    #./scripts/prebuild-kata.sh SolveSATWithGrover && \
+    #./scripts/prebuild-kata.sh SuperdenseCoding && \
     ./scripts/prebuild-kata.sh Superposition && \
     ./scripts/prebuild-kata.sh Teleportation && \
-    ./scripts/prebuild-kata.sh TruthTables && \
+    #./scripts/prebuild-kata.sh TruthTables && \
     # Exclude Unitary patterns, since it times out in Binder prebuild
     #./scripts/prebuild-kata.sh UnitaryPatterns && \
     ./scripts/prebuild-kata.sh tutorials/ComplexArithmetic ComplexArithmetic.ipynb && \
@@ -57,7 +57,7 @@ RUN cd ${HOME} && \
     ./scripts/prebuild-kata.sh tutorials/LinearAlgebra LinearAlgebra.ipynb && \
     ./scripts/prebuild-kata.sh tutorials/MultiQubitGates MultiQubitGates.ipynb && \
     ./scripts/prebuild-kata.sh tutorials/MultiQubitSystems MultiQubitSystems.ipynb && \
-    ./scripts/prebuild-kata.sh tutorials/Oracles Oracles.ipynb && \
+    #./scripts/prebuild-kata.sh tutorials/Oracles Oracles.ipynb && \
     ./scripts/prebuild-kata.sh tutorials/Qubit Qubit.ipynb && \
     ./scripts/prebuild-kata.sh tutorials/RandomNumberGeneration RandomNumberGenerationTutorial.ipynb && \
     ./scripts/prebuild-kata.sh tutorials/SingleQubitGates SingleQubitGates.ipynb && \


### PR DESCRIPTION
This change removes several least frequently used katas from Binder prebuild to reduce the build time on Binder.