### PR TITLE
Added entanglement swapping as an extra task to the Teleportation kata

### DIFF
--- a/Teleportation/ReferenceImplementation.qs
+++ b/Teleportation/ReferenceImplementation.qs
@@ -75,12 +75,12 @@ namespace Quantum.Kata.Teleportation {
     }
     
     // Task 1.8. Entanglement swapping
-    operation EntanglementSwapping_Reference (qubitPairAlice : Qubit[], qubitPairBob : Qubit[]) : Unit {
-        CNOT(qubitPairAlice[0], qubitPairBob[0]);
-        H(qubitPairAlice[0]);
+    operation EntanglementSwapping_Reference (entangledPairAlice : Qubit[], entangledPairBob : Qubit[]) : Unit {
+        CNOT(entangledPairAlice[0], entangledPairBob[0]);
+        H(entangledPairAlice[0]);
         
-        let classicalBits = (M(qubitPairAlice[0]) == One, M(qubitPairBob[0]) == One);
-        ReconstructMessage_Reference(qubitPairBob[1], classicalBits);
+        let classicalBits = (M(entangledPairAlice[0]) == One, M(entangledPairBob[0]) == One);
+        ReconstructMessage_Reference(entangledPairBob[1], classicalBits);
     }
     
     //////////////////////////////////////////////////////////////////

--- a/Teleportation/ReferenceImplementation.qs
+++ b/Teleportation/ReferenceImplementation.qs
@@ -74,15 +74,13 @@ namespace Quantum.Kata.Teleportation {
         return Measure([basis], [qBob]) == One;
     }
     
-    // Task 1.7. Entanglement swapping
-    operation EntanglementSwapping_Reference (qubitPairAlice : Qubit[], qubitPairBob : Qubit[]) : (Bool, Bool) {
+    // Task 1.8. Entanglement swapping
+    operation EntanglementSwapping_Reference (qubitPairAlice : Qubit[], qubitPairBob : Qubit[]) : Unit {
         CNOT(qubitPairAlice[0], qubitPairBob[0]);
         H(qubitPairAlice[0]);
         
         let classicalBits = (M(qubitPairAlice[0]) == One, M(qubitPairBob[0]) == One);
         ReconstructMessage_Reference(qubitPairBob[1], classicalBits);
-
-        return (M(qubitPairAlice[1]) == One, M(qubitPairBob[1]) == One);
     }
     
     //////////////////////////////////////////////////////////////////

--- a/Teleportation/ReferenceImplementation.qs
+++ b/Teleportation/ReferenceImplementation.qs
@@ -74,6 +74,16 @@ namespace Quantum.Kata.Teleportation {
         return Measure([basis], [qBob]) == One;
     }
     
+    // Task 1.7. Entanglement swapping
+    operation EntanglementSwapping_Reference (qubitPairAlice : Qubit[], qubitPairBob : Qubit[]) : (Bool, Bool) {
+        CNOT(qubitPairAlice[0], qubitPairBob[0]);
+        H(qubitPairAlice[0]);
+        
+        let classicalBits = (M(qubitPairAlice[0]) == One, M(qubitPairBob[0]) == One);
+        ReconstructMessage_Reference(qubitPairBob[1], classicalBits);
+
+        return (M(qubitPairAlice[1]) == One, M(qubitPairBob[1]) == One);
+    }
     
     //////////////////////////////////////////////////////////////////
     // Part II. Teleportation using different entangled pair
@@ -177,5 +187,4 @@ namespace Quantum.Kata.Teleportation {
             X(qCharlie);
         }
     }
-    
 }

--- a/Teleportation/Tasks.qs
+++ b/Teleportation/Tasks.qs
@@ -170,7 +170,7 @@ namespace Quantum.Kata.Teleportation {
     // The first pair belongs to Alice and the second to Bob. 
     //
     // Hint: You may find your answers for 1.2 and 1.3 useful, as similar steps are needed here
-    operation EntanglementSwapping (qubitPairAlice : Qubit[], qubitPairBob : Qubit[]) : Unit {
+    operation EntanglementSwapping (entangledPairAlice : Qubit[], entangledPairBob : Qubit[]) : Unit {
         // ...
     }
     

--- a/Teleportation/Tasks.qs
+++ b/Teleportation/Tasks.qs
@@ -150,6 +150,40 @@ namespace Quantum.Kata.Teleportation {
 
         // ...
     }
+
+    // Task 1.8. Entanglement swapping
+    // Another fascinating effect of teleportation can be experienced when we teleport a qubit state
+    // from a qubit that was already entangled in the first place.
+    //
+    // Alice and Bob, independently from each other, each hold an entangled qubit pair in the 
+    // state |Φ⁺⟩ = (|00⟩ + |11⟩) / sqrt(2). They hand off one part of their pair to Charlie.
+    //
+    // Charlie can teleport the state from Alice's qubit onto Bob's qubit, thus teleporting the entanglement. 
+    // Just like in "standard" teleportation, Bob still needs to apply the reconstruction steps 
+    // based on Charlie's measurement results.
+    //
+    // The practical outcome is that the entangled state |Φ⁺⟩ = (|00⟩ + |11⟩) / sqrt(2) now spans across 
+    // Alice's and Bob's qubits - the ones that they didn't send to Charlie. They are now maximally entangled
+    // even though they never interacted in the first place!
+    //
+    // Goal: Entangle one part of Alice's input qubits pair with one part of Bob's input qubit pair,
+    // without the two qubits interacting with each other.
+    // Hint: You may find your answers for 1.2 and 1.3 useful, as similar steps are needed here
+    //
+    // Input: two already entangled qubit pairs in the state |Φ⁺⟩ = (|00⟩ + |11⟩) / sqrt(2) each.
+    // The first pair belongs to Alice and the second to Bob. 
+    // 
+    // Output: A pair of classical bits that hold measurement results of the qubits that weren't sent to Charlie. 
+    // The first is the result from Alice's qubit and the second from Bob's qubit.
+    operation EntanglementSwapping (qubitPairAlice : Qubit[], qubitPairBob : Qubit[]) : (Bool, Bool) {
+        CNOT(qubitPairAlice[0], qubitPairBob[0]);
+        H(qubitPairAlice[0]);
+        
+        let classicalBits = (M(qubitPairAlice[0]) == One, M(qubitPairBob[0]) == One);
+        ReconstructMessage_Reference(qubitPairBob[1], classicalBits);
+
+        return (M(qubitPairAlice[1]) == One, M(qubitPairBob[1]) == One);
+    }
     
     
     //////////////////////////////////////////////////////////////////
@@ -245,5 +279,4 @@ namespace Quantum.Kata.Teleportation {
     operation ReconstructMessageWhenThreeEntangledQubits (qCharlie : Qubit, (b1 : Bool, b2 : Bool), b3 : Bool) : Unit {
         // ...
     }
-    
 }

--- a/Teleportation/Tasks.qs
+++ b/Teleportation/Tasks.qs
@@ -152,15 +152,12 @@ namespace Quantum.Kata.Teleportation {
     }
 
     // Task 1.8. Entanglement swapping
-    // Another fascinating effect of teleportation can be experienced when we teleport a qubit state
-    // from a qubit that was already entangled in the first place.
-    //
     // Alice and Bob, independently from each other, each hold an entangled qubit pair in the 
     // state |Φ⁺⟩ = (|00⟩ + |11⟩) / sqrt(2). They hand off one part of their pair to Charlie.
     //
-    // Charlie can teleport the state from Alice's qubit onto Bob's qubit, thus teleporting the entanglement. 
-    // Just like in "standard" teleportation, Bob still needs to apply the reconstruction steps 
-    // based on Charlie's measurement results.
+    // Charlie can now teleport the state of Alice's qubit onto Bob's qubit, thus teleporting the entanglement. 
+    // Just like in "standard" teleportation, Bob still needs to apply the reconstruction steps -
+    // based on Charlie's measurement results - to the qubit still in his possession.
     //
     // The practical outcome is that the entangled state |Φ⁺⟩ = (|00⟩ + |11⟩) / sqrt(2) now spans across 
     // Alice's and Bob's qubits - the ones that they didn't send to Charlie. They are now maximally entangled
@@ -168,21 +165,13 @@ namespace Quantum.Kata.Teleportation {
     //
     // Goal: Entangle one part of Alice's input qubits pair with one part of Bob's input qubit pair,
     // without the two qubits interacting with each other.
-    // Hint: You may find your answers for 1.2 and 1.3 useful, as similar steps are needed here
     //
-    // Input: two already entangled qubit pairs in the state |Φ⁺⟩ = (|00⟩ + |11⟩) / sqrt(2) each.
+    // Inputs: Two already entangled qubit pairs in the state |Φ⁺⟩ = (|00⟩ + |11⟩) / sqrt(2) each.
     // The first pair belongs to Alice and the second to Bob. 
-    // 
-    // Output: A pair of classical bits that hold measurement results of the qubits that weren't sent to Charlie. 
-    // The first is the result from Alice's qubit and the second from Bob's qubit.
-    operation EntanglementSwapping (qubitPairAlice : Qubit[], qubitPairBob : Qubit[]) : (Bool, Bool) {
-        CNOT(qubitPairAlice[0], qubitPairBob[0]);
-        H(qubitPairAlice[0]);
-        
-        let classicalBits = (M(qubitPairAlice[0]) == One, M(qubitPairBob[0]) == One);
-        ReconstructMessage_Reference(qubitPairBob[1], classicalBits);
-
-        return (M(qubitPairAlice[1]) == One, M(qubitPairBob[1]) == One);
+    //
+    // Hint: You may find your answers for 1.2 and 1.3 useful, as similar steps are needed here
+    operation EntanglementSwapping (qubitPairAlice : Qubit[], qubitPairBob : Qubit[]) : Unit {
+        // ...
     }
     
     

--- a/Teleportation/Teleportation.ipynb
+++ b/Teleportation/Teleportation.ipynb
@@ -2,7 +2,6 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "# Teleportation Kata\n",
     "\n",
@@ -12,11 +11,11 @@
     " - An interactive demonstration can be found [on the Wolfram Demonstrations Project](http://demonstrations.wolfram.com/QuantumTeleportation/).\n",
     "\n",
     "Each task is wrapped in one operation preceded by the description of the task.  Your goal is to fill in the blank (marked with `// ...` comment) with some Q# code that solves the task. To verify your answer, run the cell using Ctrl+Enter (⌘+Enter on macOS)."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "## Part I. Standard Teleportation\n",
     "We split the teleportation protocol into several steps:\n",
@@ -24,11 +23,11 @@
     "* Preparation (creating the entangled pair of qubits that are sent to Alice and Bob).\n",
     "* Sending the message (Alice's task): Entangling the message qubit with Alice's qubit and extracting two classical bits to be sent to Bob.\n",
     "* Reconstructing the message (Bob's task): Using the two classical bits Bob received from Alice to get Bob's qubit into the state in which the message qubit had been originally.  Finally, we compose these steps into the complete teleportation protocol."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "### Task 1.1. Entangled pair\n",
     "\n",
@@ -37,24 +36,36 @@
     "**Goal:**  prepare a Bell state $|\\Phi^{+}\\rangle = \\frac{1}{\\sqrt{2}}(|00\\rangle + |11\\rangle)$ on these qubits.\n",
     "\n",
     "> In the context of the quantum teleportation protocol, this is the preparation step: qubits qAlice and qBob will be sent to Alice and Bob, respectively."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 2,
    "source": [
     "%kata T11_Entangle \n",
     "\n",
     "operation Entangle (qAlice : Qubit, qBob : Qubit) : Unit {\n",
     "    // ...\n",
     "}"
-   ]
+   ],
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": [
+       "Success!"
+      ],
+      "application/json": ""
+     },
+     "metadata": {},
+     "execution_count": 2
+    }
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "### Task 1.2. Send the message (Alice's task)\n",
     "\n",
@@ -67,13 +78,12 @@
     "**Output**:\n",
     "Two classical bits Alice will send to Bob via classical channel as a tuple of Bool values. The first bit in the tuple should hold the result of measurement of the message qubit, the second bit - the result of measurement of Alice's qubit.\n",
     "Represent measurement result 'One' as `true` and 'Zero' as `false`.  The state of the qubits in the end of the operation doesn't matter."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 3,
    "source": [
     "%kata T12_SendMessage \n",
     "\n",
@@ -81,11 +91,166 @@
     "    // ...\n",
     "    return (false, false);\n",
     "}"
-   ]
+   ],
+   "outputs": [
+    {
+     "output_type": "display_data",
+     "data": {
+      "text/plain": [
+       "Reloading workspace: done!"
+      ],
+      "application/json": {
+       "LastUpdated": "2021-09-30T20:53:59.350992+02:00",
+       "IsCompleted": true,
+       "Description": "Reloading workspace",
+       "Subtask": "done"
+      }
+     },
+     "metadata": {}
+    },
+    {
+     "output_type": "stream",
+     "name": "stderr",
+     "text": [
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(20,22): error QS3035: Unexpected code fragment.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(84,38): error QS3035: Unexpected code fragment.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(115,33): error QS3216: Expecting \")\".\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(115,13): error QS3215: Expecting \"(\".\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(116,41): error QS3216: Expecting \")\".\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(116,17): error QS3215: Expecting \"(\".\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(164,28): error QS3035: Unexpected code fragment.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(165,32): error QS3035: Unexpected code fragment.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(165,19): error QS3101: Syntax error in expression.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(165,19): error QS3113: Expecting iteration keyword \"in\".\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(166,41): error QS3216: Expecting \")\".\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(166,17): error QS3215: Expecting \"(\".\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(197,37): error QS3216: Expecting \")\".\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(197,13): error QS3215: Expecting \"(\".\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(198,17): error QS3035: Unexpected code fragment.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(198,13): error QS3036: An expression used as a statement must be a call expression.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(202,17): error QS3035: Unexpected code fragment.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(202,13): error QS3036: An expression used as a statement must be a call expression.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(239,38): error QS3035: Unexpected code fragment.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(240,33): error QS3216: Expecting \")\".\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(240,13): error QS3215: Expecting \"(\".\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(241,41): error QS3216: Expecting \")\".\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(241,17): error QS3215: Expecting \"(\".\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(257,38): error QS3035: Unexpected code fragment.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(274,48): error QS3035: Unexpected code fragment.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(275,33): error QS3216: Expecting \")\".\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(275,13): error QS3215: Expecting \"(\".\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(276,41): error QS3216: Expecting \")\".\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(276,17): error QS3215: Expecting \"(\".\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/ReferenceImplementation.qs(59,13): error QS3035: Unexpected code fragment.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/ReferenceImplementation.qs(59,9): error QS3036: An expression used as a statement must be a call expression.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(164,9): error QS5022: No identifier with the name \"use\" exists.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(164,14): error QS5022: No identifier with the name \"qAlice\" exists.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(164,22): error QS5022: No identifier with the name \"qBob\" exists.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(167,37): error QS5022: No identifier with the name \"qAlice\" exists.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(167,45): error QS5022: No identifier with the name \"qBob\" exists.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(168,61): error QS5022: No identifier with the name \"qAlice\" exists.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(168,76): error QS5022: No identifier with the name \"sentState\" exists.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(169,68): error QS5022: No identifier with the name \"qBob\" exists.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(170,46): error QS5022: No identifier with the name \"sentState\" exists.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(170,104): error QS5022: No identifier with the name \"sentState\" exists.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(171,27): error QS5022: No identifier with the name \"qAlice\" exists.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(171,35): error QS5022: No identifier with the name \"qBob\" exists.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(84,9): error QS5022: No identifier with the name \"use\" exists.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(84,14): error QS5022: No identifier with the name \"qMessage\" exists.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(84,24): error QS5022: No identifier with the name \"qAlice\" exists.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(84,32): error QS5022: No identifier with the name \"qBob\" exists.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(85,20): error QS5022: No identifier with the name \"qMessage\" exists.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(89,20): error QS5022: No identifier with the name \"qAlice\" exists.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(89,28): error QS5022: No identifier with the name \"qBob\" exists.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(89,34): error QS5022: No identifier with the name \"qMessage\" exists.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(93,28): error QS5022: No identifier with the name \"qBob\" exists.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(94,27): error QS5022: No identifier with the name \"qBob\" exists.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(95,19): error QS5022: No identifier with the name \"qMessage\" exists.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(95,29): error QS5022: No identifier with the name \"qAlice\" exists.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(95,37): error QS5022: No identifier with the name \"qBob\" exists.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(257,9): error QS5022: No identifier with the name \"use\" exists.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(257,14): error QS5022: No identifier with the name \"qAlice\" exists.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(257,22): error QS5022: No identifier with the name \"qBob\" exists.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(257,28): error QS5022: No identifier with the name \"qCharlie\" exists.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(259,29): error QS5022: No identifier with the name \"qAlice\" exists.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(259,37): error QS5022: No identifier with the name \"qBob\" exists.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(259,43): error QS5022: No identifier with the name \"qCharlie\" exists.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(262,47): error QS5022: No identifier with the name \"qAlice\" exists.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(262,55): error QS5022: No identifier with the name \"qBob\" exists.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(262,61): error QS5022: No identifier with the name \"qCharlie\" exists.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(265,24): error QS5022: No identifier with the name \"qAlice\" exists.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(265,32): error QS5022: No identifier with the name \"qBob\" exists.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(265,38): error QS5022: No identifier with the name \"qCharlie\" exists.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(199,15): error QS5022: No identifier with the name \"qubitsAlice\" exists.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(200,18): error QS5022: No identifier with the name \"qubitsAlice\" exists.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(200,34): error QS5022: No identifier with the name \"qubitsAlice\" exists.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(203,15): error QS5022: No identifier with the name \"qubitsBob\" exists.\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stderr",
+     "text": [
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(204,18): error QS5022: No identifier with the name \"qubitsBob\" exists.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(204,32): error QS5022: No identifier with the name \"qubitsBob\" exists.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(206,34): error QS5022: No identifier with the name \"qubitsAlice\" exists.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(206,47): error QS5022: No identifier with the name \"qubitsBob\" exists.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(207,31): error QS5022: No identifier with the name \"qubitsAlice\" exists.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(207,57): error QS5022: No identifier with the name \"qubitsBob\" exists.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(20,9): error QS5022: No identifier with the name \"use\" exists.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(20,14): error QS5022: No identifier with the name \"q0\" exists.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(20,18): error QS5022: No identifier with the name \"q1\" exists.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(22,18): error QS5022: No identifier with the name \"q0\" exists.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(22,22): error QS5022: No identifier with the name \"q1\" exists.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(25,36): error QS5022: No identifier with the name \"q0\" exists.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(25,40): error QS5022: No identifier with the name \"q1\" exists.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(28,24): error QS5022: No identifier with the name \"q0\" exists.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(28,28): error QS5022: No identifier with the name \"q1\" exists.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(274,9): error QS5022: No identifier with the name \"use\" exists.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(274,14): error QS5022: No identifier with the name \"qMessage\" exists.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(274,24): error QS5022: No identifier with the name \"qAlice\" exists.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(274,32): error QS5022: No identifier with the name \"qBob\" exists.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(274,38): error QS5022: No identifier with the name \"qCharlie\" exists.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(277,23): error QS5022: No identifier with the name \"qMessage\" exists.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(278,47): error QS5022: No identifier with the name \"qAlice\" exists.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(278,55): error QS5022: No identifier with the name \"qBob\" exists.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(278,61): error QS5022: No identifier with the name \"qCharlie\" exists.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(279,54): error QS5022: No identifier with the name \"qAlice\" exists.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(279,62): error QS5022: No identifier with the name \"qMessage\" exists.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(280,41): error QS5022: No identifier with the name \"qBob\" exists.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(281,60): error QS5022: No identifier with the name \"qCharlie\" exists.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(282,31): error QS5022: No identifier with the name \"qCharlie\" exists.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(283,35): error QS5022: No identifier with the name \"qCharlie\" exists.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(284,27): error QS5022: No identifier with the name \"qMessage\" exists.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(284,37): error QS5022: No identifier with the name \"qAlice\" exists.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(284,45): error QS5022: No identifier with the name \"qBob\" exists.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(284,51): error QS5022: No identifier with the name \"qCharlie\" exists.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(239,9): error QS5022: No identifier with the name \"use\" exists.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(239,14): error QS5022: No identifier with the name \"qMessage\" exists.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(239,24): error QS5022: No identifier with the name \"qAlice\" exists.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(239,32): error QS5022: No identifier with the name \"qBob\" exists.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(242,23): error QS5022: No identifier with the name \"qMessage\" exists.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(243,37): error QS5022: No identifier with the name \"qAlice\" exists.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(243,45): error QS5022: No identifier with the name \"qBob\" exists.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(244,41): error QS5022: No identifier with the name \"qAlice\" exists.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(244,49): error QS5022: No identifier with the name \"qBob\" exists.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(244,55): error QS5022: No identifier with the name \"qMessage\" exists.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(245,31): error QS5022: No identifier with the name \"qBob\" exists.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(246,35): error QS5022: No identifier with the name \"qBob\" exists.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(247,27): error QS5022: No identifier with the name \"qMessage\" exists.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(247,37): error QS5022: No identifier with the name \"qAlice\" exists.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(247,45): error QS5022: No identifier with the name \"qBob\" exists.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/ReferenceImplementation.qs(61,15): error QS5022: No identifier with the name \"message\" exists.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/ReferenceImplementation.qs(64,39): error QS5022: No identifier with the name \"message\" exists.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/ReferenceImplementation.qs(65,59): error QS5022: No identifier with the name \"message\" exists.\n",
+      "/Users/filipw/dev/QuantumKatas/Teleportation/ReferenceImplementation.qs(66,15): error QS5022: No identifier with the name \"message\" exists.\n"
+     ]
+    }
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "### Task 1.3. Reconstruct the message (Bob's task)\n",
     "\n",
@@ -96,24 +261,24 @@
     "2. The tuple of classical bits received from Alice, in the format used in task 1.2.\n",
     "\n",
     "**Goal** : Transform Bob's qubit qBob into the state in which the message qubit had been originally."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "%kata T13_ReconstructMessage \n",
     "\n",
     "operation ReconstructMessage (qBob : Qubit, (b1 : Bool, b2 : Bool)) : Unit {\n",
     "    // ...\n",
     "}"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "### Task 1.4. Standard teleportation protocol\n",
     "\n",
@@ -125,24 +290,24 @@
     "2. The message qubit qMessage in the state $|\\psi\\rangle$ to be teleported.\n",
     "\n",
     "**Goal:** Transform Bob's qubit qBob into the state $|\\psi\\rangle$. The state of the qubits qAlice and qMessage in the end of the operation doesn't matter."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "%kata T14_StandardTeleport\n",
     "\n",
     "operation StandardTeleport (qAlice : Qubit, qBob : Qubit, qMessage : Qubit) : Unit {\n",
     "    // ...\n",
     "}"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "### Task 1.5. Prepare a state and send it as a message (Alice's task)\n",
     "\n",
@@ -157,13 +322,12 @@
     "**Output:** \n",
     "\n",
     "Two classical bits Alice will send to Bob via classical channel as a tuple of Bool values.  The first bit in the tuple should hold the result of measurement of the message qubit, the second bit - the result of measurement of Alice's qubit.  Represent measurement result 'One' as `true` and 'Zero' as `false`. The state of the qubit qAlice in the end of the operation doesn't matter."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "%kata T15_PrepareAndSendMessage\n",
     "\n",
@@ -171,11 +335,12 @@
     "    // ...\n",
     "    return (false, false);\n",
     "}"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "### Task 1.6. Reconstruct and measure the message state (Bob's task)\n",
     "\n",
@@ -190,13 +355,12 @@
     "**Output:** A Bool indicating the eigenstate in which the message qubit was prepared, 'One' as `true` and 'Zero' as `false`.  The state of the qubit qBob in the end of the operation doesn't matter.\n",
     "\n",
     "> To get the output, transform Bob's qubit qBob into the state in which the message qubit was originally prepared, then measure it. "
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "%kata T16_ReconstructAndMeasureMessage\n",
     "\n",
@@ -205,11 +369,12 @@
     "    // ...\n",
     "    return false;\n",
     "}"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "### Task 1.7. Testing standard quantum teleportation\n",
     "\n",
@@ -223,13 +388,12 @@
     "  <summary><b>Need a hint? Click here</b</summary>\n",
     "  You may find your answers for 1.5 and 1.6 useful\n",
     "</details>"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "open Microsoft.Quantum.Diagnostics;\n",
     "\n",
@@ -237,20 +401,63 @@
     "    // ...\n",
     "    return \"Success!\";\n",
     "}"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "%simulate Run_StandardTeleport"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "source": [
+    "### Task 1.8. Entanglement swapping\n",
+    "\n",
+    "Alice and Bob, independently from each other, each hold an entangled qubit pair in the state $|\\Phi^{+}\\rangle = \\frac{1}{\\sqrt{2}} \\big(|00\\rangle + |11\\rangle\\big)$. They hand off one part of their pair to Charlie.\n",
+    "\n",
+    "Charlie can now teleport the state of Alice's qubit onto Bob's qubit, thus teleporting the entanglement. \n",
+    "Just like in \"standard\" teleportation, Bob still needs to apply the reconstruction steps - based on Charlie's measurement results - to the qubit still in his possession.\n",
+    "\n",
+    "The practical outcome is that the entangled state $|\\Phi^{+}\\rangle = \\frac{1}{\\sqrt{2}} \\big(|00\\rangle + |11\\rangle\\big)$. now spans across Alice's and Bob's qubits - the ones that they didn't send to Charlie. They are now maximally entangled even though they never interacted in the first place!\n",
+    "\n",
+    "**Goal:** Entangle one part of Alice's input qubits pair with one part of Bob's input qubit pair, without the two qubits interacting with each other.\n",
+    "\n",
+    "**Inputs:**\n",
+    "\n",
+    "Two already entangled qubit pairs in the state $|\\Phi^{+}\\rangle = \\frac{1}{\\sqrt{2}} \\big(|00\\rangle + |11\\rangle\\big)$. each. The first pair belongs to Alice and the second to Bob. \n",
+    "\n",
+    "**Output:**\n",
+    "\n",
+    "A pair of classical bits that hold measurement results of the qubits that weren't sent to Charlie. The first is the result from Alice's qubit and the second from Bob's qubit.\n",
+    "\n",
+    "<details>\n",
+    "  <summary><b>Need a hint? Click here</b</summary>\n",
+    "  You may find your answers for 1.2 and 1.3 useful, as similar steps are needed here\n",
+    "</details>"
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "source": [
+    "%kata T18_EntanglementSwapping\n",
+    "\n",
+    "operation EntanglementSwapping (qubitPairAlice : Qubit[], qubitPairBob : Qubit[]) : Unit {\n",
+    "    // ...\n",
+    "}"
+   ],
+   "outputs": [],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "source": [
     "## Part II. Teleportation using different entangled pair\n",
     "\n",
@@ -262,80 +469,80 @@
     "2. The tuple of classical bits received from Alice, in the format used in task 1.2.\n",
     "\n",
     "The goal is to transform Bob's qubit qBob into the state in which the message qubit had been originally."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "### Task 2.1. Reconstruct the message if the entangled qubits were in the state $|\\Phi^{-}\\rangle = \\frac{1}{\\sqrt{2}} \\big(|00\\rangle - |11\\rangle\\big)$"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "%kata T21_ReconstructMessage_PhiMinus\n",
     "\n",
     "operation ReconstructMessage_PhiMinus (qBob : Qubit, (b1 : Bool, b2 : Bool)) : Unit {\n",
     "    // ...\n",
     "}"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "### Task 2.2. Reconstruct the message if the entangled qubits were in the state $|\\Psi^{+}\\rangle = \\frac{1}{\\sqrt{2}} \\big(|01\\rangle + |10\\rangle\\big)$"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "%kata T22_ReconstructMessage_PsiPlus\n",
     "\n",
     "operation ReconstructMessage_PsiPlus (qBob : Qubit, (b1 : Bool, b2 : Bool)) : Unit {\n",
     "    // ...\n",
     "}"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "### Task 2.3. Reconstruct the message if the entangled qubits were in the state $|\\Psi^{-}\\rangle = \\frac{1}{\\sqrt{2}} \\big(|01\\rangle - |10\\rangle\\big)$"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "%kata T23_ReconstructMessage_PsiMinus\n",
     "\n",
     "operation ReconstructMessage_PsiMinus (qBob : Qubit, (b1 : Bool, b2 : Bool)) : Unit {\n",
     "    // ...\n",
     "}"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "## Part III. Principle of deferred measurement\n",
     "\n",
     "The principle of deferred measurement claims that measurements can be moved from an intermediate stage of a quantum circuit to the end of the circuit.  If the measurement results are used to perform classically controlled operations, they can be replaced by controlled quantum operations."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "### Task 3.1. Measurement-free teleportation.\n",
     "\n",
@@ -347,34 +554,34 @@
     "2. The message qubit qMessage in the state $|\\psi\\rangle$ to be teleported.\n",
     "\n",
     "**Goal:** transform Bob's qubit qBob into the state $|\\psi\\rangle$ using no measurements.  At the end of the operation qubits qAlice and qMessage should not be entangled with qBob."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "%kata T31_MeasurementFreeTeleport\n",
     "\n",
     "operation MeasurementFreeTeleport (qAlice : Qubit, qBob : Qubit, qMessage : Qubit) : Unit {\n",
     "    // ...\n",
     "}"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "## Part IV. Teleportation with three entangled qubits\n",
     "\n",
     "Quantum teleportation using entangled states other than Bell pairs is also feasible.  Here we look at just one of many possible schemes - in it a state is transferred from Alice to a third participant Charlie, but this may only be accomplished if Charlie\n",
     "has the trust of the second participant Bob."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "### Task 4.1. Entangled trio\n",
     "\n",
@@ -383,24 +590,24 @@
     "**Goal:** create an entangled state $|\\Psi^{3}\\rangle = \\frac{1}{2} \\big(|000\\rangle + |011\\rangle + |101\\rangle + |110\\rangle\\big)$ on these qubits.\n",
     "\n",
     "In the context of the quantum teleportation protocol, this is the preparation step: qubits qAlice, qBob, and qCharlie will be sent to Alice, Bob, and Charlie respectively."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "%kata T41_EntangleThreeQubits\n",
     "\n",
     "operation EntangleThreeQubits (qAlice : Qubit, qBob : Qubit, qCharlie : Qubit) : Unit {\n",
     "    // ...\n",
     "}"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "### Task 4.2. Reconstruct the message (Charlie's task)\n",
     "\n",
@@ -412,20 +619,21 @@
     "3. A classical bit resulting from the measurement of Bob's qubit.\n",
     "\n",
     "**Goal:** Transform Charlie's qubit qCharlie into the state in which the message qubit had been originally."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "%kata T42_ReconstructMessageWhenThreeEntangledQubits\n",
     "\n",
     "operation ReconstructMessageWhenThreeEntangledQubits (qCharlie : Qubit, (b1 : Bool, b2 : Bool), b3 : Bool) : Unit {\n",
     "    // ...\n",
     "}"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   }
  ],
  "metadata": {
@@ -438,7 +646,7 @@
    "file_extension": ".qs",
    "mimetype": "text/x-qsharp",
    "name": "qsharp",
-   "version": "0.12"
+   "version": "0.14"
   }
  },
  "nbformat": 4,

--- a/Teleportation/Teleportation.ipynb
+++ b/Teleportation/Teleportation.ipynb
@@ -41,7 +41,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "source": [
     "%kata T11_Entangle \n",
     "\n",
@@ -49,19 +49,7 @@
     "    // ...\n",
     "}"
    ],
-   "outputs": [
-    {
-     "output_type": "execute_result",
-     "data": {
-      "text/plain": [
-       "Success!"
-      ],
-      "application/json": ""
-     },
-     "metadata": {},
-     "execution_count": 2
-    }
-   ],
+   "outputs": [],
    "metadata": {}
   },
   {
@@ -83,7 +71,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "source": [
     "%kata T12_SendMessage \n",
     "\n",
@@ -92,161 +80,7 @@
     "    return (false, false);\n",
     "}"
    ],
-   "outputs": [
-    {
-     "output_type": "display_data",
-     "data": {
-      "text/plain": [
-       "Reloading workspace: done!"
-      ],
-      "application/json": {
-       "LastUpdated": "2021-09-30T20:53:59.350992+02:00",
-       "IsCompleted": true,
-       "Description": "Reloading workspace",
-       "Subtask": "done"
-      }
-     },
-     "metadata": {}
-    },
-    {
-     "output_type": "stream",
-     "name": "stderr",
-     "text": [
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(20,22): error QS3035: Unexpected code fragment.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(84,38): error QS3035: Unexpected code fragment.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(115,33): error QS3216: Expecting \")\".\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(115,13): error QS3215: Expecting \"(\".\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(116,41): error QS3216: Expecting \")\".\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(116,17): error QS3215: Expecting \"(\".\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(164,28): error QS3035: Unexpected code fragment.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(165,32): error QS3035: Unexpected code fragment.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(165,19): error QS3101: Syntax error in expression.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(165,19): error QS3113: Expecting iteration keyword \"in\".\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(166,41): error QS3216: Expecting \")\".\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(166,17): error QS3215: Expecting \"(\".\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(197,37): error QS3216: Expecting \")\".\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(197,13): error QS3215: Expecting \"(\".\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(198,17): error QS3035: Unexpected code fragment.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(198,13): error QS3036: An expression used as a statement must be a call expression.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(202,17): error QS3035: Unexpected code fragment.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(202,13): error QS3036: An expression used as a statement must be a call expression.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(239,38): error QS3035: Unexpected code fragment.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(240,33): error QS3216: Expecting \")\".\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(240,13): error QS3215: Expecting \"(\".\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(241,41): error QS3216: Expecting \")\".\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(241,17): error QS3215: Expecting \"(\".\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(257,38): error QS3035: Unexpected code fragment.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(274,48): error QS3035: Unexpected code fragment.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(275,33): error QS3216: Expecting \")\".\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(275,13): error QS3215: Expecting \"(\".\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(276,41): error QS3216: Expecting \")\".\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(276,17): error QS3215: Expecting \"(\".\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/ReferenceImplementation.qs(59,13): error QS3035: Unexpected code fragment.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/ReferenceImplementation.qs(59,9): error QS3036: An expression used as a statement must be a call expression.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(164,9): error QS5022: No identifier with the name \"use\" exists.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(164,14): error QS5022: No identifier with the name \"qAlice\" exists.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(164,22): error QS5022: No identifier with the name \"qBob\" exists.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(167,37): error QS5022: No identifier with the name \"qAlice\" exists.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(167,45): error QS5022: No identifier with the name \"qBob\" exists.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(168,61): error QS5022: No identifier with the name \"qAlice\" exists.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(168,76): error QS5022: No identifier with the name \"sentState\" exists.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(169,68): error QS5022: No identifier with the name \"qBob\" exists.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(170,46): error QS5022: No identifier with the name \"sentState\" exists.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(170,104): error QS5022: No identifier with the name \"sentState\" exists.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(171,27): error QS5022: No identifier with the name \"qAlice\" exists.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(171,35): error QS5022: No identifier with the name \"qBob\" exists.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(84,9): error QS5022: No identifier with the name \"use\" exists.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(84,14): error QS5022: No identifier with the name \"qMessage\" exists.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(84,24): error QS5022: No identifier with the name \"qAlice\" exists.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(84,32): error QS5022: No identifier with the name \"qBob\" exists.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(85,20): error QS5022: No identifier with the name \"qMessage\" exists.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(89,20): error QS5022: No identifier with the name \"qAlice\" exists.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(89,28): error QS5022: No identifier with the name \"qBob\" exists.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(89,34): error QS5022: No identifier with the name \"qMessage\" exists.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(93,28): error QS5022: No identifier with the name \"qBob\" exists.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(94,27): error QS5022: No identifier with the name \"qBob\" exists.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(95,19): error QS5022: No identifier with the name \"qMessage\" exists.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(95,29): error QS5022: No identifier with the name \"qAlice\" exists.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(95,37): error QS5022: No identifier with the name \"qBob\" exists.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(257,9): error QS5022: No identifier with the name \"use\" exists.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(257,14): error QS5022: No identifier with the name \"qAlice\" exists.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(257,22): error QS5022: No identifier with the name \"qBob\" exists.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(257,28): error QS5022: No identifier with the name \"qCharlie\" exists.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(259,29): error QS5022: No identifier with the name \"qAlice\" exists.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(259,37): error QS5022: No identifier with the name \"qBob\" exists.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(259,43): error QS5022: No identifier with the name \"qCharlie\" exists.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(262,47): error QS5022: No identifier with the name \"qAlice\" exists.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(262,55): error QS5022: No identifier with the name \"qBob\" exists.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(262,61): error QS5022: No identifier with the name \"qCharlie\" exists.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(265,24): error QS5022: No identifier with the name \"qAlice\" exists.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(265,32): error QS5022: No identifier with the name \"qBob\" exists.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(265,38): error QS5022: No identifier with the name \"qCharlie\" exists.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(199,15): error QS5022: No identifier with the name \"qubitsAlice\" exists.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(200,18): error QS5022: No identifier with the name \"qubitsAlice\" exists.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(200,34): error QS5022: No identifier with the name \"qubitsAlice\" exists.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(203,15): error QS5022: No identifier with the name \"qubitsBob\" exists.\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stderr",
-     "text": [
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(204,18): error QS5022: No identifier with the name \"qubitsBob\" exists.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(204,32): error QS5022: No identifier with the name \"qubitsBob\" exists.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(206,34): error QS5022: No identifier with the name \"qubitsAlice\" exists.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(206,47): error QS5022: No identifier with the name \"qubitsBob\" exists.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(207,31): error QS5022: No identifier with the name \"qubitsAlice\" exists.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(207,57): error QS5022: No identifier with the name \"qubitsBob\" exists.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(20,9): error QS5022: No identifier with the name \"use\" exists.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(20,14): error QS5022: No identifier with the name \"q0\" exists.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(20,18): error QS5022: No identifier with the name \"q1\" exists.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(22,18): error QS5022: No identifier with the name \"q0\" exists.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(22,22): error QS5022: No identifier with the name \"q1\" exists.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(25,36): error QS5022: No identifier with the name \"q0\" exists.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(25,40): error QS5022: No identifier with the name \"q1\" exists.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(28,24): error QS5022: No identifier with the name \"q0\" exists.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(28,28): error QS5022: No identifier with the name \"q1\" exists.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(274,9): error QS5022: No identifier with the name \"use\" exists.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(274,14): error QS5022: No identifier with the name \"qMessage\" exists.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(274,24): error QS5022: No identifier with the name \"qAlice\" exists.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(274,32): error QS5022: No identifier with the name \"qBob\" exists.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(274,38): error QS5022: No identifier with the name \"qCharlie\" exists.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(277,23): error QS5022: No identifier with the name \"qMessage\" exists.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(278,47): error QS5022: No identifier with the name \"qAlice\" exists.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(278,55): error QS5022: No identifier with the name \"qBob\" exists.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(278,61): error QS5022: No identifier with the name \"qCharlie\" exists.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(279,54): error QS5022: No identifier with the name \"qAlice\" exists.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(279,62): error QS5022: No identifier with the name \"qMessage\" exists.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(280,41): error QS5022: No identifier with the name \"qBob\" exists.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(281,60): error QS5022: No identifier with the name \"qCharlie\" exists.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(282,31): error QS5022: No identifier with the name \"qCharlie\" exists.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(283,35): error QS5022: No identifier with the name \"qCharlie\" exists.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(284,27): error QS5022: No identifier with the name \"qMessage\" exists.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(284,37): error QS5022: No identifier with the name \"qAlice\" exists.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(284,45): error QS5022: No identifier with the name \"qBob\" exists.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(284,51): error QS5022: No identifier with the name \"qCharlie\" exists.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(239,9): error QS5022: No identifier with the name \"use\" exists.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(239,14): error QS5022: No identifier with the name \"qMessage\" exists.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(239,24): error QS5022: No identifier with the name \"qAlice\" exists.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(239,32): error QS5022: No identifier with the name \"qBob\" exists.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(242,23): error QS5022: No identifier with the name \"qMessage\" exists.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(243,37): error QS5022: No identifier with the name \"qAlice\" exists.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(243,45): error QS5022: No identifier with the name \"qBob\" exists.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(244,41): error QS5022: No identifier with the name \"qAlice\" exists.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(244,49): error QS5022: No identifier with the name \"qBob\" exists.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(244,55): error QS5022: No identifier with the name \"qMessage\" exists.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(245,31): error QS5022: No identifier with the name \"qBob\" exists.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(246,35): error QS5022: No identifier with the name \"qBob\" exists.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(247,27): error QS5022: No identifier with the name \"qMessage\" exists.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(247,37): error QS5022: No identifier with the name \"qAlice\" exists.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/Tests.qs(247,45): error QS5022: No identifier with the name \"qBob\" exists.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/ReferenceImplementation.qs(61,15): error QS5022: No identifier with the name \"message\" exists.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/ReferenceImplementation.qs(64,39): error QS5022: No identifier with the name \"message\" exists.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/ReferenceImplementation.qs(65,59): error QS5022: No identifier with the name \"message\" exists.\n",
-      "/Users/filipw/dev/QuantumKatas/Teleportation/ReferenceImplementation.qs(66,15): error QS5022: No identifier with the name \"message\" exists.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "metadata": {}
   },
   {
@@ -449,7 +283,7 @@
    "source": [
     "%kata T18_EntanglementSwapping\n",
     "\n",
-    "operation EntanglementSwapping (qubitPairAlice : Qubit[], qubitPairBob : Qubit[]) : Unit {\n",
+    "operation EntanglementSwapping (entangledPairAlice : Qubit[], entangledPairBob : Qubit[]) : Unit {\n",
     "    // ...\n",
     "}"
    ],

--- a/Teleportation/Tests.qs
+++ b/Teleportation/Tests.qs
@@ -189,6 +189,24 @@ namespace Quantum.Kata.Teleportation {
         TeleportPreparedStateTestLoop(PrepareAndSendMessage_Reference, ReconstructAndMeasureMessage);
     }
     
+    @Test("QuantumSimulator")
+    operation T17_EntanglementSwapping () : Unit {
+        
+        let numRepetitions = 100;
+
+        for i in 0 .. numRepetitions {
+            use qubitsAlice = Qubit[2];
+            H(qubitsAlice[0]);
+            CNOT(qubitsAlice[0], qubitsAlice[1]);
+
+            use qubitsBob = Qubit[2];
+            H(qubitsBob[0]);
+            CNOT(qubitsBob[0], qubitsBob[1]);
+            
+            let (c1, c2) = EntanglementSwapping(qubitsAlice, qubitsBob);
+            EqualityFactB(c1, c2, "Alice's and Bob's qubits should have been maximally entangled, but measurement result produced different classical bits.");
+        }
+    }
     
     // ------------------------------------------------------
     // Test variations of the teleport protocol using different state prep procedures
@@ -266,5 +284,4 @@ namespace Quantum.Kata.Teleportation {
             }
         }
     }
-    
 }

--- a/Teleportation/Tests.qs
+++ b/Teleportation/Tests.qs
@@ -190,7 +190,7 @@ namespace Quantum.Kata.Teleportation {
     }
     
     @Test("QuantumSimulator")
-    operation T17_EntanglementSwapping () : Unit {
+    operation T18_EntanglementSwapping () : Unit {
         
         let numRepetitions = 100;
 
@@ -203,7 +203,8 @@ namespace Quantum.Kata.Teleportation {
             H(qubitsBob[0]);
             CNOT(qubitsBob[0], qubitsBob[1]);
             
-            let (c1, c2) = EntanglementSwapping(qubitsAlice, qubitsBob);
+            EntanglementSwapping(qubitsAlice, qubitsBob);
+            let (c1, c2) = (M(qubitsAlice[1]) == One, M(qubitsBob[1]) == One);
             EqualityFactB(c1, c2, "Alice's and Bob's qubits should have been maximally entangled, but measurement result produced different classical bits.");
         }
     }


### PR DESCRIPTION
Hello 👋 I thought it might be an interesting task to have entanglement swapping as a task in the Teleportation kata.

The user starts with two maximally entangled `Phi^{+}` pair, one belonging to Alice and the other to Bob. The task is to use one qubit of each pair to produce an entanglement of the other two qubits - without any interaction between those.