### PR TITLE
Updated prebuild-kata script to exclude projects without .csproj files

### DIFF
--- a/scripts/prebuild-kata.sh
+++ b/scripts/prebuild-kata.sh
@@ -4,5 +4,10 @@ KATA_NOTEBOOK=${2:-$1.ipynb}
 
 echo "Prebuilding: $KATA_NOTEBOOK in $KATA_FOLDER kata..."
 
+count=`ls -1 *.csproj 2>/dev/null | wc -l`
+if [ $count != 0 ]
+then 
 dotnet build $KATA_FOLDER
+fi
+
 jupyter nbconvert $KATA_FOLDER/$KATA_NOTEBOOK --execute --to markdown  --allow-errors  --ExecutePreprocessor.timeout=120


### PR DESCRIPTION
#662 

- [x] Make changes in the prebuild-kata.sh file to exclude **dotnet build $KATA_FOLDER** for folders without .csproj files