### PR TITLE
[Superposition] Fix several typos

### DIFF
--- a/Superposition/Workbook_Superposition.ipynb
+++ b/Superposition/Workbook_Superposition.ipynb
@@ -246,7 +246,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[Return to task 4 of the Superposition kata.](./Superposition.ipynb#superposition-of-basis-vectors-with-phase-flip)"
+    "[Return to task 1.4 of the Superposition kata.](./Superposition.ipynb#superposition-of-basis-vectors-with-phase-flip)"
    ]
   },
   {
@@ -694,7 +694,7 @@
    "file_extension": ".qs",
    "mimetype": "text/x-qsharp",
    "name": "qsharp",
-   "version": "0.10"
+   "version": "0.14"
   }
  },
  "nbformat": 4,

--- a/Superposition/Workbook_Superposition_Part2.ipynb
+++ b/Superposition/Workbook_Superposition_Part2.ipynb
@@ -37,7 +37,7 @@
     "\n",
     "Let's use the 2-qubit circuit as a building block to construct the circuit for 3 qubits. First, let's add a third qubit to the above circuit:\n",
     "\n",
-    "<img src=\"./img/Task8Hadamardand3rdqubitircuit.png\"/>\n",
+    "<img src=\"./img/Task8HadamardAnd3rdqubitircuit.png\"/>\n",
     "\n",
     "Comparing the state prepared by this circuit with the desired end state, we see that they differ only in the third (rightmost) qubit:\n",
     "\n",


### PR DESCRIPTION
File name typo is its case, which matters for rendering notebooks on Linux machines.