### PR TITLE
Switched to a new dump functionality exposed by QuantumSimulator

### DIFF
--- a/utilities/Microsoft.Quantum.Katas/KataMagic.cs
+++ b/utilities/Microsoft.Quantum.Katas/KataMagic.cs
@@ -169,10 +169,11 @@ namespace Microsoft.Quantum.Katas
 
             try
             {
-                var qsim = CreateSimulator(channel);
+                var qsim = CreateSimulator();
 
                 qsim.DisableExceptionPrinting();
                 qsim.DisableLogToConsole();
+                qsim.OnLog += channel.Stdout;
 
                 qsim.OnDisplayableDiagnostic += channel.Display;
 
@@ -206,8 +207,8 @@ namespace Microsoft.Quantum.Katas
         /// Creates the instance of the simulator to use to run the Test 
         /// (for now always CounterSimulator from the same package).
         /// </summary>
-        public virtual SimulatorBase CreateSimulator(IChannel channel) =>
-            new CounterSimulator().WithJupyterDisplay(channel, ConfigurationSource);
+        public virtual SimulatorBase CreateSimulator() =>
+            new CounterSimulator();
 
         /// <summary>
         /// Returns the OperationInfo with the Test to run based on the given name.


### PR DESCRIPTION
This PR is a stage two of the three below (fixes [this failure](https://dev.azure.com/ms-quantum-public/Microsoft%20Quantum%20(public)/_build/results?buildId=35503&view=logs&j=7c911cd3-259e-5f9c-1871-e3ecdf8c19e2&t=49e51bed-911d-557f-68be-a68a81a3af9b&l=972) in `iqsharp` [PR](https://github.com/microsoft/iqsharp/pull/544)):
* Preparing the QuantumSimulator for unifying the Dump(). Providing the new dump functionality on the `qsharp-runtime` repo side ([PR](https://github.com/microsoft/qsharp-runtime/pull/867)).
* Redirecting the `IQSharp` ([PR](https://github.com/microsoft/iqsharp/pull/544)) and `QuantumKatas` repo to the new dump functionality in `qsharp-runtime` repo.
* Cleaning-up the commented out code on the `qsharp-runtime` repo side.