### PR TITLE
Update SingleQubitGates.ipynb Description of Pauli Matrices

### DIFF
--- a/tutorials/SingleQubitGates/SingleQubitGates.ipynb
+++ b/tutorials/SingleQubitGates/SingleQubitGates.ipynb
@@ -259,7 +259,7 @@
    "source": [
     "## Pauli Gates\n",
     "\n",
-    "The Pauli gates, named after [Wolfgang Pauli](https://en.wikipedia.org/wiki/Wolfgang_Pauli), are based on the so-called **Pauli matrices**. All three Pauli gates are **self-adjoint**, meaning that each one is its own inverse.\n",
+    "The Pauli gates, named after [Wolfgang Pauli](https://en.wikipedia.org/wiki/Wolfgang_Pauli), are based on the so-called **Pauli matrices**. All three Pauli gates are **Hermitian** and **Unitary**, meaning that each one is its own inverse.\n",
     "\n",
     "<table style=\"border:1px solid\">\n",
     "    <col width=50>\n",


### PR DESCRIPTION
Changed Description of Pauli Matrices from just Self-Adjoint to Hermitian AND Unitary. A matrix has to be Hermitian AND Unitary to be equal to its own inverse. Being Hermitian is not enough.
I acknowledge Self-Adjoint and Hermitian are used interchangeably (I just prefer Hermitian :) )