### PR TITLE
[ExploringDJAlgo] Add M.Q.Providers.IonQ package

### DIFF
--- a/tutorials/ExploringDeutschJozsaAlgorithm/DeutschJozsaAlgorithmTutorial.csproj
+++ b/tutorials/ExploringDeutschJozsaAlgorithm/DeutschJozsaAlgorithmTutorial.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Quantum.Katas" Version="0.21.2112180703" />
     <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.21.2112180703" />
+    <PackageReference Include="Microsoft.Quantum.Providers.IonQ" Version="0.21.2112180703" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />


### PR DESCRIPTION
Part IV of the tutorial uses Azure Quantum magic commands from a Q# notebook. Setting an execution target requires the corresponding NuGet package to run. When this notebook is executed locally, the NuGet package is restored on the fly, but when running on Binder, we disable package recovery to speed up IQ# startup, so cell execution fails. Adding this package as a dependency allows to fetch it at Binder initialization time, and later cell execution succeeds.