### PR TITLE
Removing paths from qdk-sync trigger

### DIFF
--- a/.github/workflows/qdk-sync.yml
+++ b/.github/workflows/qdk-sync.yml
@@ -1,11 +1,10 @@
 name: Sync QDK repos
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
-    paths:
-      - 'utilities/**'
 
 jobs:
   sync-repos:


### PR DESCRIPTION
Currently we only trigger a qdk build when changes on utilities, but sometimes we've seen problems when changes to Katas.
This removes the paths so every commit to main triggers a new qdk build.
Also adding the `workflow_dispatch` event so we can trigger this on demand with other branches.