### PR TITLE
[UnitaryPatterns] Remove editorial links

### DIFF
--- a/UnitaryPatterns/README.md
+++ b/UnitaryPatterns/README.md
@@ -4,8 +4,3 @@ The "Unitary Patterns" kata offers tasks on creating unitary transformations whi
 with matrices of certain shapes (with certain pattern of zero and non-zero values).
 
 You can [run the Unitary Patterns kata as a Jupyter Notebook](https://mybinder.org/v2/gh/Microsoft/QuantumKatas/main?urlpath=/notebooks/UnitaryPatterns%2FUnitaryPatterns.ipynb)!
-
-A lot of tasks of this kata have been featured in the Microsoft Q# Coding Contest - Winter 2019. 
-You can find the descriptions of their solutions in the editorials for the 
-[warmup round](https://assets.codeforces.com/rounds/1115/warmup-editorial.pdf) and for the 
-[main contest](https://codeforces.com/blog/entry/65702).


### PR DESCRIPTION
Codeforces links appear to be unreliable from our CI point of view, and these editorials are superseded by the workbooks (added after the last README update).