### PR TITLE
Moving Python requirements to a requirements.txt file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+jinja2==3.0.3
+jupyter
+matplotlib
+numpy
+pytest
+pyzmq==19.0.2
+qsharp
+setuptools
+wheel

--- a/scripts/steps-init.yml
+++ b/scripts/steps-init.yml
@@ -15,7 +15,7 @@ steps:
     architecture: 'x64'
   displayName: 'Use Python 3.7'
 
-- script: pip install setuptools wheel pytest jupyter numpy matplotlib qsharp pyzmq==19.0.2 jinja2==3.0.3
+- script: pip install -r requirements.txt
   displayName: 'Install Python tools'
 
 - powershell: ./install-iqsharp.ps1


### PR DESCRIPTION
Moving the list of packages we use for validation into its own requirements.txt file, so it's easier to setup the environment outside the build pipeline.