### PR TITLE
[Superposition] Fix typo in URL

### DIFF
--- a/Superposition/Workbook_Superposition.ipynb
+++ b/Superposition/Workbook_Superposition.ipynb
@@ -628,7 +628,7 @@
     "    <col width=50>\n",
     "    <col width=300>\n",
     "    <tr bgcolor=\"white\">\n",
-    "        <td bgcolor=\"#FFFFFF\" style=\"text-align:center\"><img src=\"./img/Task6HadamardCNOTCircuit.PNG\"/></td>\n",
+    "        <td bgcolor=\"#FFFFFF\" style=\"text-align:center\"><img src=\"./img/Task6HadamardCNOTCircuit.png\"/></td>\n",
     "        <td bgcolor=\"#FFFFFF\" style=\"text-align:center;font-size: 30px\">$\\Leftrightarrow$</td>\n",
     "        <td bgcolor=\"#FFFFFF\" style=\"text-align:center;font-size: 20px\">$\\frac{1}{\\sqrt2} \\begin{bmatrix} 1 & 0 & 1 & 0 \\\\ 0 & 1 & 0 & 1 \\\\ 0 & 1 & 0 & -1 \\\\ \\underset{|\\Phi^{+}\\rangle}{\\underbrace{1}} & \\underset{|\\Psi^{+}\\rangle}{\\underbrace{0}} & \\underset{|\\Phi^{-}\\rangle}{\\underbrace{-1}} & \\underset{|\\Psi^{-}\\rangle}{\\underbrace{0}} \\end{bmatrix}$</td>\n",
     "      </tr>      \n",


### PR DESCRIPTION
At the end of the [Superposition workbook](https://github.com/microsoft/QuantumKatas/blob/main/Superposition/Workbook_Superposition.ipynb) there is a typo in the circuit image URL.