### PR TITLE
Fix typo in Superposition workbook part II

### DIFF
--- a/Superposition/Workbook_Superposition_Part2.ipynb
+++ b/Superposition/Workbook_Superposition_Part2.ipynb
@@ -853,7 +853,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In Q#, $R_y$ gate is represented as [Ry](https://docs.microsoft.com/qsharp/api/qsharp/microsoft.quantum.intrinsic.ry) operation. Note that you have to apply $R_y(2\\alpha)$, not $R_y(\\alpha)$; Q# does not have implicit type casing from `Int` to `Double`, so you have to calculate the angle parameter of the operation as `2.0 * alpha`, using a double constant 2.0 instead of an integer 2."
+    "In Q#, $R_y$ gate is represented as [Ry](https://docs.microsoft.com/qsharp/api/qsharp/microsoft.quantum.intrinsic.ry) operation. Note that you have to apply $R_y(2\\alpha)$, not $R_y(\\alpha)$; Q# does not have implicit type casting from `Int` to `Double`, so you have to calculate the angle parameter of the operation as `2.0 * alpha`, using a double constant 2.0 instead of an integer 2."
    ]
   },
   {


### PR DESCRIPTION
I've changed "type casing" into "type casting"