### PR TITLE
Cleanup solution for task 1.7 in QFT Workbok

### DIFF
--- a/QFT/Workbook_QFT.ipynb
+++ b/QFT/Workbook_QFT.ipynb
@@ -471,8 +471,13 @@
     "\n",
     "You've already found a way to prepare a binary fraction exponent in place in task 1.5: the state $\\frac{1}{\\sqrt{2}} \\big(|0\\rangle + e^{2\\pi i \\cdot 0.j_1 j_2 ... j_n} |1\\rangle\\big) \\otimes |j_2 ... j_n\\rangle$ can be created by first applying the Hadamard gate to qubit $|j_1\\rangle$, then applying a succession of controlled rotations using qubits $|j_k\\rangle$ with increasing values of $k$ as controls, so that an extra phase term all the way up to $e^{2\\pi i \\cdot j_n/2^{n}}$ is added with each rotation. \n",
     "\n",
-    "This will prepare the first qubit in the right state. You'll see that $j_1$ doesn't appear in the rest of the expression for the target state, so we won't need to use it for the rest of the state preparation.\n",
-    "\n",
+    "This will prepare the first qubit in the right state. You'll see that $j_1$ doesn't appear in the rest of the expression for the target state, so we won't need to use it for the rest of the state preparation.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "To prepare the remaining qubits in the right states, we can work backwards from this state.\n",
     "The second qubit in the sequence needs to be prepared in the state $\\frac{1}{\\sqrt{2}} \\big(|0\\rangle + e^{2\\pi i \\cdot 0.j_2 ... j_{n-1} j_n} |1\\rangle\\big)$. \n",
     "Similarly, we can do this by applying a Hadamard gate to the qubit $|j_2\\rangle$ and then using qubits $|j_3\\rangle$ to $|j_n\\rangle$ to apply $n-2$ controlled rotation gates with $k=2^2$ to $k=2^{n-1}$ to $|j_2\\rangle$. \n",

--- a/QFT/Workbook_QFT.ipynb
+++ b/QFT/Workbook_QFT.ipynb
@@ -471,23 +471,6 @@
     "\n",
     "You've already found a way to prepare a binary fraction exponent in place in task 1.5: the state $\\frac{1}{\\sqrt{2}} \\big(|0\\rangle + e^{2\\pi i \\cdot 0.j_1 j_2 ... j_n} |1\\rangle\\big) \\otimes |j_2 ... j_n\\rangle$ can be created by first applying the Hadamard gate to qubit $|j_1\\rangle$, then applying a succession of controlled rotations using qubits $|j_k\\rangle$ with increasing values of $k$ as controls, so that an extra phase term all the way up to $e^{2\\pi i \\cdot j_n/2^{n}}$ is added with each rotation. \n",
     "\n",
-    "This will prepare the first qubit in the right state. You'll see that $j_1$ doesn't appear in the rest of the expression for the target state, so we won't need to use it for the rest of the state preparation.\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Solution\n",
-    "\n",
-    "Let's use the hint and start by preparing the described state with the qubits reversed:\n",
-    "\n",
-    "$$\\frac{1}{\\sqrt{2}} \\big(|0\\rangle + exp(2\\pi i \\cdot 0.j_1 j_2 ... j_{n-1} j_n) |1\\rangle\\big) \\otimes ...\n",
-    "\\otimes \\frac{1}{\\sqrt{2}} \\big(|0\\rangle + exp(2\\pi i \\cdot 0.j_{n-1} j_n) |1\\rangle\\big)\n",
-    "\\otimes \\frac{1}{\\sqrt{2}} \\big(|0\\rangle + exp(2\\pi i \\cdot 0.j_n) |1\\rangle\\big)$$\n",
-    "\n",
-    "You've already found a way to prepare a binary fraction exponent in place in task 1.5: the state $\\frac{1}{\\sqrt{2}} \\big(|0\\rangle + e^{2\\pi i \\cdot 0.j_1 j_2 ... j_n} |1\\rangle\\big) \\otimes |j_2 ... j_n\\rangle$ can be created by first applying the Hadamard gate to qubit $|j_1\\rangle$, then applying a succession of controlled rotations using qubits $|j_k\\rangle$ with increasing values of $k$ as controls, so that an extra phase term all the way up to $e^{2\\pi i \\cdot j_n/2^{n}}$ is added with each rotation. \n",
-    "\n",
     "This will prepare the first qubit in the right state. You'll see that $j_1$ doesn't appear in the rest of the expression for the target state, so we won't need to use it for the rest of the state preparation.\n",
     "\n",
     "To prepare the remaining qubits in the right states, we can work backwards from this state.\n",


### PR DESCRIPTION
We have two solution blocks for task 1.7 with second one containing extra contents when compared to the first one. Hence, removing the first solution block.