### PR TITLE
[Superposition] Restore link to Bloch sphere presentation

### DIFF
--- a/Superposition/Workbook_Superposition_Part2.ipynb
+++ b/Superposition/Workbook_Superposition_Part2.ipynb
@@ -843,9 +843,9 @@
     "Looking at the other two gates, $R_x$ gate rotates the qubit state around the X axis and thus takes the qubit state out of the X-Z plane, introducing complex coefficients. $R_z$ gate rotates the qubit state around the Z axis, so it doesn't modify the $|0\\rangle$ state which lies on the Z axis.\n",
     "<br/><br/> \n",
     "In case you are surprised to see the $|0\\rangle$ and $|1\\rangle$ vectors 180 degrees apart from each other, the Bloch sphere represents orthogonal vectors as opposite points on the sphere.  \n",
-    "You can learn more about the Bloch sphere in <a href=\"https://en.wikipedia.org/wiki/Bloch_sphere\">this article</a>.</td>\n",
+    "You can learn more about the Bloch sphere in <a href=\"https://web.cecs.pdx.edu/~mperkows/june2007/bloch-sphere.pdf\">this presentation</a>.</td>\n",
     "        <td style=\"text-align:center; font-size: 14px; background-color:white; border:0\"><img src=\"./img/blochsphere.png\"/></td> \n",
-    "      </tr>    \n",
+    "      </tr>\n",
     "</table>"
    ]
   },
@@ -1687,7 +1687,7 @@
    "file_extension": ".qs",
    "mimetype": "text/x-qsharp",
    "name": "qsharp",
-   "version": "0.14"
+   "version": "0.24"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
We had to remove this link in https://github.com/microsoft/QuantumKatas/pull/751 and replace it with a link to Wikipedia, but now I've found the new home of the original presentation. It's still the best presentation on Bloch sphere I've ever seen, so bringing it back.