### PR TITLE
Fix display issue for `\bra` and `\ket` in VSCode

### DIFF
--- a/tutorials/MultiQubitSystemMeasurements/MultiQubitSystemMeasurements.ipynb
+++ b/tutorials/MultiQubitSystemMeasurements/MultiQubitSystemMeasurements.ipynb
@@ -11,8 +11,8 @@
     "This will include measuring a single qubit in a multi-qubit system, as well as measuring multiple qubits simultaneously. \n",
     "\n",
     "We recommend to go through the [tutorial that introduces single qubit system measurements](../SingleQubitSystemMeasurements/SingleQubitSystemMeasurements.ipynb) before starting this one.\n",
-    "$\\newcommand{\\ket}[1]{\\left|#1\\right>}$\n",
-    "$\\newcommand{\\bra}[1]{\\left<#1\\right|}$"
+    "$\\renewcommand{\\ket}[1]{\\left\\lvert#1\\right\\rangle}$\n",
+    "$\\renewcommand{\\bra}[1]{\\left\\langle#1\\right\\rvert}$"
    ]
   },
   {

--- a/tutorials/MultiQubitSystemMeasurements/Workbook_MultiQubitSystemMeasurements.ipynb
+++ b/tutorials/MultiQubitSystemMeasurements/Workbook_MultiQubitSystemMeasurements.ipynb
@@ -21,8 +21,8 @@
     "1. Basic linear algebra\n",
     "2. Single and multi-qubit systems\n",
     "3. Single and multi-qubit gates\n",
-    "$\\newcommand{\\ket}[1]{\\left|#1\\right>}$\n",
-    "$\\newcommand{\\bra}[1]{\\left<#1\\right|}$"
+    "$\\renewcommand{\\ket}[1]{\\left\\lvert#1\\right\\rangle}$\n",
+    "$\\renewcommand{\\bra}[1]{\\left\\langle#1\\right\\rvert}$"
    ]
   },
   {

--- a/tutorials/SingleQubitSystemMeasurements/SingleQubitSystemMeasurements.ipynb
+++ b/tutorials/SingleQubitSystemMeasurements/SingleQubitSystemMeasurements.ipynb
@@ -16,8 +16,8 @@
     "* Pauli basis measurements\n",
     "* Measurements in arbitrary orthogonal bases\n",
     "* Representing measurements as projector operators\n",
-    "$\\newcommand{\\ket}[1]{\\left|#1\\right>}$\n",
-    "$\\newcommand{\\bra}[1]{\\left<#1\\right|}$"
+    "$\\renewcommand{\\ket}[1]{\\left\\lvert#1\\right\\rangle}$\n",
+    "$\\renewcommand{\\bra}[1]{\\left\\langle#1\\right\\rvert}$"
    ]
   },
   {

--- a/tutorials/SingleQubitSystemMeasurements/Workbook_SingleQubitSystemMeasurements.ipynb
+++ b/tutorials/SingleQubitSystemMeasurements/Workbook_SingleQubitSystemMeasurements.ipynb
@@ -21,8 +21,8 @@
     "1. Basic linear algebra\n",
     "2. The concept of a qubit\n",
     "3. Single-qubit gates\n",
-    "$\\newcommand{\\ket}[1]{\\left|#1\\right>}$\n",
-    "$\\newcommand{\\bra}[1]{\\left<#1\\right|}$"
+    "$\\renewcommand{\\ket}[1]{\\left\\lvert#1\\right\\rangle}$\n",
+    "$\\renewcommand{\\bra}[1]{\\left\\langle#1\\right\\rvert}$"
    ]
   },
   {


### PR DESCRIPTION
Fixes an issue where the definition of `\bra` and `\ket` collides with loaded `braket` package in VSCode and causes error messages (that do not actually break functionality) to be displayed.

Further styles `bra` and `ket` more concisely with more accurate symbols 