### PR TITLE
Fix Typo in MultiQubitGate.ipynb

### DIFF
--- a/tutorials/MultiQubitGates/MultiQubitGates.ipynb
+++ b/tutorials/MultiQubitGates/MultiQubitGates.ipynb
@@ -294,7 +294,7 @@
     "> * Two, as we can clearly see, are computational basis states $|00\\rangle$ and $|01\\rangle$ with eigen values $1$ and $1$, respectively (the basis states that are not affected by the gate). \n",
     "> * The other two are $|1\\rangle \\otimes |+\\rangle = \\frac{1}{\\sqrt{2}}\\big(|10\\rangle + |11\\rangle\\big)$ and $|1\\rangle \\otimes |-\\rangle = \\frac{1}{\\sqrt{2}}\\big(|10\\rangle - |11\\rangle\\big)$ with eigenvalues $1$ and $-1$, respectively:\n",
     ">\n",
-    "> $$\\text{CNOT}|0\\rangle \\otimes |0\\rangle = |0\\rangle \\otimes |1\\rangle$$\n",
+    "> $$\\text{CNOT}|0\\rangle \\otimes |0\\rangle = |0\\rangle \\otimes |0\\rangle$$\n",
     "> $$\\text{CNOT}|0\\rangle \\otimes |1\\rangle = |0\\rangle \\otimes |1\\rangle$$\n",
     "> $$\\text{CNOT}|1\\rangle \\otimes |+\\rangle = |1\\rangle \\otimes |+\\rangle$$\n",
     "> $$\\text{CNOT}|1\\rangle \\otimes |-\\rangle = -|1\\rangle \\otimes |-\\rangle$$\n",


### PR DESCRIPTION
Hello.
I've fixed a formula of CNOT gate's eigen vector whick looks like a typo.