### PR TITLE
Introducing ControlledOnBitString explicitly in Oracles tutorial

### DIFF
--- a/tutorials/Oracles/Oracles.ipynb
+++ b/tutorials/Oracles/Oracles.ipynb
@@ -171,7 +171,22 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "> Notice that the input state above is an equal superposition of all basis states. \n",
+    "We introduced the function [ControlledOnBitString](https://docs.microsoft.com/qsharp/api/qsharp/microsoft.quantum.canon.controlledonbitstring) provided by the Q# Standard library.\n",
+    "It defines a variant of a gate controlled on a state specified by a bit mask; for example, bit mask `[true, false]` means that the gate should be applied only if the two control qubits are in the $|10\\rangle$ state.\n",
+    " \n",
+    "The sequence of steps that implement this variant are:\n",
+    "1. Apply the $X$ gate to each control qubit that corresponds to a `false` element of the bit mask. After this, if the control qubits started in the $|10\\rangle$ state, they'll end up in the $|11\\rangle$ state, and if they started in any other state, they'll end up in any state but $|11\\rangle$.\n",
+    "2. Apply the regular controlled version of the gate.\n",
+    "3. Apply the $X$ gate to the same qubits to return them to their original state.\n",
+    "\n",
+    "Due to this [conjugation pattern](https://learn.microsoft.com/en-us/azure/quantum/user-guide/language/statements/conjugations), the time complexity of this function is 2 * N, where N is the number of control qubits. To learn its internal implementation (and the very similar [ControlledOnInt](https://docs.microsoft.com/qsharp/api/qsharp/microsoft.quantum.canon.controlledonint)), please refer to the [Q# source code](https://github.com/microsoft/QuantumLibraries/blob/c0b851735542117cf6d73f8946ab6eef8c84384d/Standard/src/Canon/Utils/ControlledOnBitString.qs#L107)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> Notice that the input state in the demo above is an equal superposition of all basis states. \n",
     "After applying the oracle the absolute values of all amplitudes are the same, but the states $|010\\rangle$ and $|101\\rangle$ had their phase flipped to negative!  \n",
     "> Recall that these two states are exactly the inputs for which $f(x) = 1$, thus they are exactly the two states we expect to experience a phase flip!"
    ]


### PR DESCRIPTION
Added an explanation of ControlledOnBitString when introducing it for the first time in the Oracles tutorial. Also included links to the documentation and source code per @tcNickolas and @Manvi-Agrawal.