### PR TITLE
Fixing the undesirable dependencies issue for qdk

### DIFF
--- a/scripts/manifest.ps1
+++ b/scripts/manifest.ps1
@@ -23,8 +23,8 @@ $artifacts = @{
     ) | ForEach-Object { Join-Path $Env:NUGET_OUTDIR "$_.$Env:NUGET_VERSION.nupkg" };
 
     Assemblies = @(
-        ".\utilities\Common\bin\$Env:BUILD_CONFIGURATION\netstandard2.1\Microsoft.Quantum.Katas.Common.dll",
-        ".\utilities\Microsoft.Quantum.Katas\bin\$Env:BUILD_CONFIGURATION\netstandard2.1\Microsoft.Quantum.Katas.dll"
+        ".\utilities\Common\bin\$Env:BUILD_CONFIGURATION\net6.0\Microsoft.Quantum.Katas.Common.dll",
+        ".\utilities\Microsoft.Quantum.Katas\bin\$Env:BUILD_CONFIGURATION\net6.0\Microsoft.Quantum.Katas.dll"
     ) | ForEach-Object { Join-Path $PSScriptRoot (Join-Path ".." $_) };
 } 
 

--- a/utilities/Common/Common.csproj
+++ b/utilities/Common/Common.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.Quantum.Sdk/0.27.253010">
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <AssemblyName>Microsoft.Quantum.Katas.Common</AssemblyName>
   </PropertyGroup>

--- a/utilities/Microsoft.Quantum.Katas/Microsoft.Quantum.Katas.csproj
+++ b/utilities/Microsoft.Quantum.Katas/Microsoft.Quantum.Katas.csproj
@@ -22,7 +22,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Common\Common.csproj" PrivateAssets="all" />
-    <BuildOutputInPackage Include="..\Common\bin\$(Configuration)\netstandard2.1\Microsoft.Quantum.Katas.Common.dll" />
+    <BuildOutputInPackage Include="..\Common\bin\$(Configuration)\net6.0\Microsoft.Quantum.Katas.Common.dll" />
   </ItemGroup>
 
   <ItemGroup>

--- a/utilities/Microsoft.Quantum.Katas/Microsoft.Quantum.Katas.csproj
+++ b/utilities/Microsoft.Quantum.Katas/Microsoft.Quantum.Katas.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
 


### PR DESCRIPTION
DevOps 48463, 48471.
The `netstandard2.1` target framework has undesirable dependencies, migrating the affected packages to `net6.0`.

Multi-repo PR:
[Q#Compiler](https://github.com/microsoft/qsharp-compiler/pull/1601), [Q#RT](https://github.com/microsoft/qsharp-runtime/pull/1121), [iQ#](https://github.com/microsoft/iqsharp/pull/760), [QuantumLibraries](https://github.com/microsoft/QuantumLibraries/pull/656), [Quantum-NC](https://github.com/microsoft/Quantum-NC/pull/84), [Quantum](https://github.com/microsoft/Quantum/pull/771) (samples), [Katas](https://github.com/microsoft/QuantumKatas/pull/868), QDK, and a private repo.

PR CI build can fail, but overall qdk.release (0.27.254480) has succeeded.