### PR TITLE
[Ubuntu] Update instruction to run jupyter in new window

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -200,9 +200,14 @@ After you are done with editing the notebook, choose ```View -> Cell Toolbar -> 
 3. To observe your changes when running Q# Jupyter Notebook:
    1. Set the environment variable `IQSHARP_LOG_LEVEL=Debug`.
       > The environment variable is case-sensitive.
-   2. Navigate to your project folder and run the following command:
+   2. Navigate to your project folder and run the following command:  
+      **For Windows:**  
       ```bash
       $ start jupyter notebook <your notebook name>
+      ```
+      **For Ubuntu:**
+      ```bash
+      $ gnome-terminal -- start jupyter notebook <your notebook name>
       ```
       > This will launch Q# Jupyter Notebooks server in a new window, which is
       > helpful in debugging the magics since logging is quite noisy.

--- a/README.md
+++ b/README.md
@@ -193,10 +193,19 @@ $ jupyter notebook index.ipynb
 
 This will open the notebook that contains a list of all katas and tutorials, and you will be able to navigate to the one you want using links.
 
-> Note that this will start Jupyter Notebooks server in the same command line window you used to run the command. If you want to keep using that window for navigation, you can launch Jupyter Notebooks server in a new window using the following commands (on Windows):
+> **NOTE:** 
+> This will start Jupyter Notebooks server in the same command line window you used to run the command. If you want to keep using that window for navigation, you can launch Jupyter Notebooks server in a new window using the following commands:   
+>
+> **For Windows:**
 > ```bash
 > $ cd QuantumKatas/
 > $ start jupyter notebook index.ipynb
+> ```
+>  
+> **For Ubuntu:**
+> ```bash
+> $ cd QuantumKatas/
+> $ gnome-terminal -- start jupyter notebook index.ipynb
 > ```
 
 You can also open an individual notebook directly, but this might render internal links invalid:


### PR DESCRIPTION
Hi @tcNickolas , recently I moved to Ubuntu machine and noticed that `start jupyter notebook <your notebook name>` didn't work. I found an equivalent command `gnome-terminal -- start jupyter notebook <your notebook name>` that serves the same purpose. Also attached the screenshots from new and the old wikis in PR description.

Updated new Readme
---
![image](https://user-images.githubusercontent.com/40084144/222520506-276f2a4f-bbc8-4229-8e7b-92db0dc69a94.png)
---


Old Readme
----
![image](https://user-images.githubusercontent.com/40084144/222520158-6e463077-6f9e-4697-9d90-562b865745ad.png)
----

Updated Contributing guide
----
![image](https://user-images.githubusercontent.com/40084144/222520763-0508f769-7dcb-4a42-ba5e-ce0b6cce0f2f.png)
----

Old Contributing guide
----
![image](https://user-images.githubusercontent.com/40084144/222521295-f61b819e-2f09-41f8-b737-a7f623c73703.png)
----