### PR TITLE
Remove version pin from pyzmq

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ jupyter
 matplotlib
 numpy
 pytest
-pyzmq==19.0.2
+pyzmq
 qsharp
 setuptools
 wheel


### PR DESCRIPTION
Removing the version pin from pyzmq due to version conflict breaking build.